### PR TITLE
Schedule payments through action scheduler

### DIFF
--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -7,6 +7,7 @@ use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Background_Queue;
 use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Transactions;
 use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Instant_Capture;
 use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Payment_Actions;
+use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Scheduler;
 
 /**
  * @SuppressWarnings(PHPMD.CamelCaseClassName)
@@ -30,36 +31,42 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 	/**
 	 * Access Token
+	 *
 	 * @var string
 	 */
 	public $access_token = '';
 
 	/**
 	 * Payee Id
+	 *
 	 * @var string
 	 */
 	public $payee_id = '';
 
 	/**
 	 * Test Mode
+	 *
 	 * @var string
 	 */
 	public $testmode = 'no';
 
 	/**
 	 * Debug Mode
+	 *
 	 * @var string
 	 */
 	public $debug = 'yes';
 
 	/**
 	 * IP Checking
+	 *
 	 * @var string
 	 */
 	public $ip_check = 'yes';
 
 	/**
 	 * Locale
+	 *
 	 * @var string
 	 */
 	public $culture = 'en-US';
@@ -73,6 +80,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 	/**
 	 * Instant Capture
+	 *
 	 * @var array
 	 */
 	public $instant_capture = array();
@@ -89,6 +97,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 	/**
 	 * Swedbank Pay ip addresses
+	 *
 	 * @var array
 	 */
 	public $gateway_ip_addresses = array( '91.132.170.1' );
@@ -105,18 +114,19 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 	/**
 	 * Init
+	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 */
 	public function __construct() {
 		$this->transactions = Swedbank_Pay_Transactions::instance();
 
-		$this->id           = 'payex_checkout';
-		$this->has_fields   = true;
-		$this->method_title = __( 'Swedbank Pay Payment Menu', 'swedbank-pay-woocommerce-checkout' );
+		$this->id                 = 'payex_checkout';
+		$this->has_fields         = true;
+		$this->method_title       = __( 'Swedbank Pay Payment Menu', 'swedbank-pay-woocommerce-checkout' );
 		$this->method_description = __( 'Provides the Swedbank Pay Payment Menu for WooCommerce', 'swedbank-pay-woocommerce-checkout' );
-		//$this->icon         = apply_filters( 'woocommerce_swedbank_pay_payments_icon', plugins_url( '/assets/images/checkout.svg', dirname( __FILE__ ) ) );
-		$this->supports     = array(
+		// $this->icon         = apply_filters( 'woocommerce_swedbank_pay_payments_icon', plugins_url( '/assets/images/checkout.svg', dirname( __FILE__ ) ) );
+		$this->supports = array(
 			'products',
 			'refunds',
 		);
@@ -178,6 +188,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 	/**
 	 * Initialise Settings Form Fields
+	 *
 	 * @return string|void
 	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
@@ -198,7 +209,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				'label'   => __( 'Enable Swedbank Pay Test Mode', 'swedbank-pay-woocommerce-checkout' ),
 				'default' => $this->testmode,
 			),
-			'title'            => array(
+			'title'           => array(
 				'title'       => __( 'Title', 'swedbank-pay-woocommerce-checkout' ),
 				'type'        => 'text',
 				'description' => __(
@@ -224,7 +235,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				'custom_attributes' => array(
 					'required' => 'required',
 				),
-				'sanitize_callback' => function( $value ) {
+				'sanitize_callback' => function ( $value ) {
 					if ( empty( $value ) ) {
 						throw new Exception( __( '"Payee Id" field can\'t be empty.', 'swedbank-pay-woocommerce-checkout' ) );
 					}
@@ -240,7 +251,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				'custom_attributes' => array(
 					'required' => 'required',
 				),
-				'sanitize_callback' => function( $value ) {
+				'sanitize_callback' => function ( $value ) {
 					if ( empty( $value ) ) {
 						throw new Exception( __( '"Access Token" field can\'t be empty.', 'swedbank-pay-woocommerce-checkout' ) );
 					}
@@ -289,7 +300,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				'description'       => __( 'The URL that will be used for showing the customer logo. Must be a picture with maximum 50px height and 400px width. Require https.', 'swedbank-pay-woocommerce-checkout' ),
 				'desc_tip'          => true,
 				'default'           => '',
-				'sanitize_callback' => function( $value ) {
+				'sanitize_callback' => function ( $value ) {
 					if ( ! empty( $value ) ) {
 						if ( ! filter_var( $value, FILTER_VALIDATE_URL ) ) {
 							throw new Exception( __( 'Logo Url is invalid.', 'swedbank-pay-woocommerce-checkout' ) );
@@ -301,7 +312,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 					return $value;
 				},
 			),
-			'autocomplete'        => array(
+			'autocomplete'    => array(
 				'title'   => __( 'Automatic order status', 'swedbank-pay-woocommerce-checkout' ),
 				'type'    => 'checkbox',
 				'label'   => __( 'Set order in completed status immediately after payment', 'swedbank-pay-woocommerce-checkout' ),
@@ -400,7 +411,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			return;
 		}
 
-		$this->api->log( WC_Log_Levels::INFO, __METHOD__, [ $order_id ] );
+		$this->api->log( WC_Log_Levels::INFO, __METHOD__, array( $order_id ) );
 		$is_finalized     = $order->get_meta( '_payex_finalized' );
 		$payment_order_id = $order->get_meta( '_payex_paymentorder_id' );
 		if ( empty( $is_finalized ) && $payment_order_id ) {
@@ -418,7 +429,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 		}
 
 		// Capture payment is applicable
-		if ( 'yes' === $this->autocomplete && $order->has_status( 'on-hold' )  ) {
+		if ( 'yes' === $this->autocomplete && $order->has_status( 'on-hold' ) ) {
 			$result = $this->payment_actions_handler->capture_payment( $order );
 			if ( ! is_wp_error( $result ) ) {
 				$order->payment_complete();
@@ -480,12 +491,13 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 		return array(
 			'result'   => 'success',
-			'redirect' => $redirect_url
+			'redirect' => $redirect_url,
 		);
 	}
 
 	/**
 	 * IPN Callback
+	 *
 	 * @return void
 	 * @throws \Exception
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -509,7 +521,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			sprintf( 'Incoming Callback. Post data: %s', var_export( $raw_body, true ) )
 		);
 
-		// Check IP address of Incoming Callback
+		// Check IP address of Incoming Callback.
 		if ( 'yes' === $this->ip_check ) {
 			if ( ! in_array(
 				WC_Geolocation::get_ip_address(),
@@ -525,7 +537,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			}
 		}
 
-		// Decode raw body
+		// Decode raw body.
 		$data = json_decode( $raw_body, true );
 		if ( JSON_ERROR_NONE !== json_last_error() ) {
 			throw new Exception( 'Invalid webhook data' );
@@ -545,7 +557,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				throw new Exception( 'A provided order key has been invalid.' );
 			}
 
-			// Validate fields
+			// Validate fields.
 			if ( ! isset( $data['paymentOrder'] ) || ! isset( $data['paymentOrder']['id'] ) ) {
 				throw new \Exception( 'Error: Invalid paymentOrder value' );
 			}
@@ -554,19 +566,27 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				throw new \Exception( 'Error: Invalid transaction number' );
 			}
 
-			// Create Background Process Task
-			$background_process = new Swedbank_Pay_Background_Queue();
-			$background_process->push_to_queue(
+			// Schedule the payment for later processing.
+			$schedule_id = as_schedule_single_action(
+				time() + 30,
+				Swedbank_Pay_Scheduler::ACTION_ID,
 				array(
 					'payment_method_id' => $this->id,
 					'webhook_data'      => $raw_body,
 				)
 			);
-			$background_process->save();
+
+			if ( 0 === $schedule_id ) {
+				$this->api->log(
+					WC_Log_Levels::ERROR,
+					sprintf( 'Error: Unable to schedule a task for %s', $this->id )
+				);
+				throw new \Exception( 'Unable to schedule a task.' );
+			}
 
 			$this->api->log(
 				WC_Log_Levels::INFO,
-				sprintf( 'Incoming Callback: Task enqueued. Transaction ID: %s', $data['transaction']['number'] )
+				sprintf( 'Incoming Callback: payment scheduled as %s. Transaction ID: %s', $schedule_id, $data['transaction']['number'] )
 			);
 		} catch ( \Exception $e ) {
 			$this->api->log( WC_Log_Levels::INFO, sprintf( 'Incoming Callback: %s', $e->getMessage() ) );
@@ -581,8 +601,8 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	 * If the gateway declares 'refunds' support, this will allow it to refund
 	 * a passed in amount.
 	 *
-	 * @param int $order_id
-	 * @param float $amount
+	 * @param int    $order_id
+	 * @param float  $amount
 	 * @param string $reason
 	 *
 	 * @return  bool|wp_error True or false based on success, or a WP_Error object
@@ -627,7 +647,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			// Refund by items
 			$result = $this->payment_actions_handler->refund_payment( $order, $lines, $reason, false );
 			if ( is_wp_error( $result ) ) {
-				return new WP_Error( 'refund', join('; ', $result->get_error_messages() ) );
+				return new WP_Error( 'refund', join( '; ', $result->get_error_messages() ) );
 			}
 
 			$order->update_meta_data( '_sb_refund_mode', 'items' );
@@ -639,7 +659,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 		// Refund by amount
 		$result = $this->payment_actions_handler->refund_payment_amount( $order, $amount );
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error( 'refund', join('; ', $result->get_error_messages() ) );
+			return new WP_Error( 'refund', join( '; ', $result->get_error_messages() ) );
 		}
 
 		$order->update_meta_data( '_sb_refund_mode', 'amount' );
@@ -651,7 +671,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	/**
 	 * Override payment method title.
 	 *
-	 * @param string $value
+	 * @param string   $value
 	 * @param WC_Order $order
 	 *
 	 * @return string
@@ -713,7 +733,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * @param bool $is_editable
+	 * @param bool     $is_editable
 	 * @param WC_Order $order
 	 *
 	 * @return bool

--- a/includes/class-swedbank-pay-plugin.php
+++ b/includes/class-swedbank-pay-plugin.php
@@ -92,20 +92,21 @@ class Swedbank_Pay_Plugin {
 	 * @SuppressWarnings(PHPMD.UnusedLocalVariable)
 	 */
 	public function includes() {
-		$vendors_dir = dirname( __FILE__ ) . '/../vendor';
+		$vendors_dir = __DIR__ . '/../vendor';
 		require_once $vendors_dir . '/autoload.php';
-		require_once( dirname( __FILE__ ) . '/functions.php' );
-		require_once( dirname( __FILE__ ) . '/interface-swedbank-pay-order-item.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-transactions.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-api.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-instant-capture.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-payment-actions.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-admin.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-thankyou.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-intl-tel.php' );
+		require_once __DIR__ . '/functions.php';
+		require_once __DIR__ . '/interface-swedbank-pay-order-item.php';
+		require_once __DIR__ . '/class-swedbank-pay-transactions.php';
+		require_once __DIR__ . '/class-swedbank-pay-api.php';
+		require_once __DIR__ . '/class-swedbank-pay-instant-capture.php';
+		require_once __DIR__ . '/class-swedbank-pay-payment-actions.php';
+		require_once __DIR__ . '/class-swedbank-pay-admin.php';
+		require_once __DIR__ . '/class-swedbank-pay-thankyou.php';
+		require_once __DIR__ . '/class-swedbank-pay-intl-tel.php';
+		require_once __DIR__ . '/class-swedbank-pay-scheduler.php';
 
 		if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
-			require_once( dirname( __FILE__ ) . '/class-swedbank-pay-blocks-support.php' );
+			require_once __DIR__ . '/class-swedbank-pay-blocks-support.php';
 		}
 	}
 
@@ -155,8 +156,9 @@ class Swedbank_Pay_Plugin {
 	 * WooCommerce Init
 	 */
 	public function woocommerce_init() {
-		include_once( dirname( __FILE__ ) . '/class-swedbank-pay-background-queue.php' );
+		include_once __DIR__ . '/class-swedbank-pay-background-queue.php';
 		self::$background_process = new Swedbank_Pay_Background_Queue();
+		Swedbank_Pay_Scheduler::get_instance();
 	}
 
 	/**
@@ -173,7 +175,7 @@ class Swedbank_Pay_Plugin {
 
 		if ( ! isset( $px_gateways[ $class_name ] ) ) {
 			// Initialize instance
-			$gateway = new $class_name;
+			$gateway = new $class_name();
 
 			if ( $gateway ) {
 				$px_gateways[] = $class_name;
@@ -205,7 +207,7 @@ class Swedbank_Pay_Plugin {
 	/**
 	 * Billing phone.
 	 *
-	 * @param string $billing_phone
+	 * @param string   $billing_phone
 	 * @param WC_Order $order
 	 *
 	 * @return string
@@ -301,6 +303,7 @@ class Swedbank_Pay_Plugin {
 
 	/**
 	 * Support Page
+	 *
 	 * @SuppressWarnings(PHPMD.Superglobals)
 	 */
 	public static function support_page() {
@@ -313,7 +316,7 @@ class Swedbank_Pay_Plugin {
 				'message'  => isset( $_GET['message'] ) ? sanitize_text_field( wp_unslash( $_GET['message'] ) ) : null, // WPCS: input var ok, CSRF ok.
 			),
 			'',
-			dirname( __FILE__ ) . '/../templates/'
+			__DIR__ . '/../templates/'
 		);
 	}
 
@@ -326,7 +329,7 @@ class Swedbank_Pay_Plugin {
 		}
 
 		// Run Database Update
-		include_once( dirname( __FILE__ ) . '/class-swedbank-pay-update.php' );
+		include_once __DIR__ . '/class-swedbank-pay-update.php';
 		Swedbank_Pay_Update::update();
 
 		echo esc_html__( 'Upgrade finished.', 'swedbank-pay-woocommerce-checkout' );
@@ -459,6 +462,7 @@ class Swedbank_Pay_Plugin {
 
 	/**
 	 * Send support message
+	 *
 	 * @SuppressWarnings(PHPMD.Superglobals)
 	 * @SuppressWarnings(PHPMD.ErrorControlOperator)
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -586,6 +590,7 @@ class Swedbank_Pay_Plugin {
 
 	/**
 	 * Handle a custom '_payex_paymentorder_id' query var to get orders with the '_payex_paymentorder_id' meta.
+	 *
 	 * @see https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query
 	 * @param array $query - Args for WP_Query.
 	 * @param array $query_vars - Query vars from WC_Order_Query.
@@ -593,10 +598,10 @@ class Swedbank_Pay_Plugin {
 	 */
 	public function handle_custom_query_var( $query, $query_vars ) {
 		if ( ! empty( $query_vars['_payex_paymentorder_id'] ) ) {
-			$query['meta_query'][] = [
-				'key' => '_payex_paymentorder_id',
+			$query['meta_query'][] = array(
+				'key'   => '_payex_paymentorder_id',
 				'value' => esc_attr( $query_vars['_payex_paymentorder_id'] ),
-			];
+			);
 		}
 
 		return $query;
@@ -609,12 +614,12 @@ class Swedbank_Pay_Plugin {
 	 */
 	public function woocommerce_blocks_support() {
 		if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
-			require_once( dirname( __FILE__ ) . '/class-swedbank-pay-blocks-support.php' );
+			require_once __DIR__ . '/class-swedbank-pay-blocks-support.php';
 
 			add_action(
 				'woocommerce_blocks_payment_method_type_registration',
-				function( PaymentMethodRegistry $payment_method_registry ) {
-					$payment_method_registry->register( new Swedbank_Pay_Blocks_Support );
+				function ( PaymentMethodRegistry $payment_method_registry ) {
+					$payment_method_registry->register( new Swedbank_Pay_Blocks_Support() );
 				}
 			);
 		}

--- a/includes/class-swedbank-pay-scheduler.php
+++ b/includes/class-swedbank-pay-scheduler.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Swedbank Pay Scheduler Class.
+ * Handles scheduled tasks for Swedbank Pay.
+ *
+ * @package SwedbankPay\Checkout\WooCommerce
+ */
+
+namespace SwedbankPay\Checkout\WooCommerce;
+
+use WC_Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+
+/**
+ * Swedbank_Pay_Scheduler Class.
+ */
+class Swedbank_Pay_Scheduler {
+	public const ACTION_ID = 'swedbank_pay_scheduler_run';
+
+	/**
+	 * @var Swedbank_Pay_Scheduler
+	 */
+	private static $instance = null;
+
+	/**
+	 * Singleton pattern
+	 *
+	 * @return Swedbank_Pay_Scheduler
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Logger instance.
+	 *
+	 * @var WC_Logger
+	 */
+	private $logger;
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		$this->logger = \wc_get_logger();
+
+		add_action( 'swedbank_pay_scheduler_run', array( $this, 'run' ), 10, 2 );
+	}
+
+	/**
+	 * Log message.
+	 *
+	 * @param string $message The message to log.
+	 */
+	private function log( $message ) {
+		$this->logger->info( $message, array( 'source' => 'swedbank_pay_queue' ) );
+	}
+
+	/**
+	 * Code to execute for each item in the queue.
+	 *
+	 * @throws \Exception If the webhook data is invalid or if the order cannot be found.
+	 *
+	 * @param string $payment_method_id The payment method ID.
+	 * @param string $webhook_data The webhook data in JSON format.
+	 *
+	 * @return false|null
+	 */
+	public function run( $payment_method_id, $webhook_data ) {
+		$this->log( sprintf( 'Start task: %s', var_export( array( $payment_method_id, $webhook_data ), true ) ) );
+
+		try {
+			$payload = $webhook_data;
+			$data    = json_decode( $payload, true );
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
+				throw new \Exception( 'Invalid webhook data' );
+			}
+
+			if ( ! isset( $data['paymentOrder'] ) || ! isset( $data['paymentOrder']['id'] ) ) {
+				throw new \Exception( 'Error: Invalid paymentOrder value' );
+			}
+
+			if ( ! isset( $data['transaction'] ) || ! isset( $data['transaction']['number'] ) ) {
+				throw new \Exception( 'Error: Invalid transaction number' );
+			}
+
+			$transaction_number = $data['transaction']['number'];
+			$payment_order_id   = $data['paymentOrder']['id'];
+
+			// Get order by `orderReference`.
+			if ( isset( $data['orderReference'] ) ) {
+				$order = wc_get_order( $data['orderReference'] );
+				if ( ! $order ) {
+					throw new \Exception( 'Failed to find order: ' . $data['orderReference'] );
+				}
+
+				$this->log(
+					sprintf(
+						'[SCHEDULER]: Found order #%s by order reference %s.',
+						$order->get_id(),
+						$data['orderReference']
+					)
+				);
+			} else {
+				// Get Order by Payment Order Id.
+				$order = swedbank_pay_get_order( $payment_order_id );
+				if ( ! $order ) {
+					throw new \Exception( 'Failed to find order: ' . $payment_order_id );
+				}
+
+				$this->log( sprintf( '[SCHEDULER]: Found order #%s by payment Order ID %s.', $order->get_id(), $payment_order_id ) );
+			}
+
+			$gateway = swedbank_pay_get_payment_method( $order );
+			if ( ! $gateway ) {
+				throw new \Exception(
+					sprintf(
+						'Can\'t retrieve payment gateway instance: %s',
+						$payment_method_id
+					)
+				);
+			}
+
+			if ( ! property_exists( $gateway, 'api' ) ||
+				! in_array( $order->get_payment_method(), Swedbank_Pay_Plugin::PAYMENT_METHODS, true ) ) {
+				$this->log(
+					sprintf(
+						'[ERROR]: Order #%s has not been paid with the swedbank pay. Payment method: %s',
+						$order->get_id(),
+						$order->get_payment_method()
+					)
+				);
+
+				return false;
+			}
+
+			$transactions = (array) $order->get_meta( '_swedbank_pay_transactions' );
+			if ( in_array( $transaction_number, $transactions, true ) ) {
+				$this->log( sprintf( '[SCHEDULER]: Transaction #%s was processed before.', $transaction_number ) );
+				return false;
+			}
+		} catch ( \Exception $e ) {
+			$this->log( sprintf( '[ERROR]: Validation error: %s', $e->getMessage() ) );
+			return false;
+		}
+
+		// @todo Use https://developer.swedbankpay.com/checkout-v3/features/core/callback
+		$result = $gateway->api->finalize_payment( $order, $transaction_number );
+		if ( is_wp_error( $result ) ) {
+			$this->log( sprintf( '[ERROR]: %s', $result->get_error_message() ) );
+			return false;
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
To maintain backwards compatibility, the existing background queue processor was not deleted. Instead, all new payments will be scheduled for processing through the action scheduler.

- added action scheduler for processing payment.
- removed pushing to the queue during direct.
- used string interpolation where applicable.

https://app.clickup.com/t/8699g3bxf