### PR TITLE
Add setting to exclude order lines from payment request

### DIFF
--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -47,18 +47,18 @@ class Swedbank_Pay_Api {
 	const MODE_TEST = 'test';
 	const MODE_LIVE = 'live';
 
-	const INTENT_AUTOCAPTURE = 'AutoCapture';
+	const INTENT_AUTOCAPTURE   = 'AutoCapture';
 	const INTENT_AUTHORIZATION = 'Authorization';
-	const INTENT_SALE = 'Sale';
+	const INTENT_SALE          = 'Sale';
 
 	const OPERATION_PURCHASE = 'Purchase';
 
-	const TYPE_VERIFICATION = 'Verification';
+	const TYPE_VERIFICATION  = 'Verification';
 	const TYPE_AUTHORIZATION = 'Authorization';
-	const TYPE_CAPTURE = 'Capture';
-	const TYPE_SALE = 'Sale';
-	const TYPE_CANCELLATION = 'Cancellation';
-	const TYPE_REVERSAL = 'Reversal';
+	const TYPE_CAPTURE       = 'Capture';
+	const TYPE_SALE          = 'Sale';
+	const TYPE_CANCELLATION  = 'Cancellation';
+	const TYPE_REVERSAL      = 'Reversal';
 
 	/**
 	 * @var string
@@ -113,13 +113,13 @@ class Swedbank_Pay_Api {
 		$callbackUrl = add_query_arg(
 			array(
 				'order_id' => $order->get_id(),
-				'key' => $order->get_order_key(),
+				'key'      => $order->get_order_key(),
 			),
 			WC()->api_request_url( get_class( $gateway ) )
 		);
 
 		$completeUrl = $gateway->get_return_url( $order );
-		$cancelUrl = $order->get_cancel_order_url_raw();
+		$cancelUrl   = $order->get_cancel_order_url_raw();
 
 		$user_agent = $order->get_customer_user_agent();
 		if ( empty( $userAgent ) ) {
@@ -135,7 +135,7 @@ class Swedbank_Pay_Api {
 						$cancelUrl,
 						$callbackUrl,
 						$gateway->terms_url,
-						$gateway->logo_url
+						$gateway->logo_url,
 					)
 				)
 			)
@@ -151,28 +151,28 @@ class Swedbank_Pay_Api {
 		$metadata = new PaymentorderMetadata();
 		$metadata->setData( 'order_id', $order->get_id() );
 
-		// Build items collection
+		// Build items collection.
 		$items = swedbank_pay_get_order_lines( $order );
 
 		$order_items = new OrderItemsCollection();
 		foreach ( $items as $item ) {
-			$orderItem = new OrderItem();
-			$orderItem
-				->setReference( $item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] )
-				->setName( $item[Swedbank_Pay_Order_Item::FIELD_NAME] )
-				->setType( $item[Swedbank_Pay_Order_Item::FIELD_TYPE] )
-				->setItemClass( $item[Swedbank_Pay_Order_Item::FIELD_CLASS] )
-				->setItemUrl( $item[Swedbank_Pay_Order_Item::FIELD_ITEM_URL] )
-				->setImageUrl( $item[Swedbank_Pay_Order_Item::FIELD_IMAGE_URL] )
-				->setDescription( $item[Swedbank_Pay_Order_Item::FIELD_DESCRIPTION] )
-				->setQuantity( $item[Swedbank_Pay_Order_Item::FIELD_QTY] )
-				->setUnitPrice( $item[Swedbank_Pay_Order_Item::FIELD_UNITPRICE] )
-				->setQuantityUnit( $item[Swedbank_Pay_Order_Item::FIELD_QTY_UNIT] )
-				->setVatPercent( $item[Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT] )
-				->setAmount( $item[Swedbank_Pay_Order_Item::FIELD_AMOUNT] )
-				->setVatAmount( $item[Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT] );
+			$order_item = new OrderItem();
+			$order_item
+			->setReference( $item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] )
+			->setName( $item[ Swedbank_Pay_Order_Item::FIELD_NAME ] )
+			->setType( $item[ Swedbank_Pay_Order_Item::FIELD_TYPE ] )
+			->setItemClass( $item[ Swedbank_Pay_Order_Item::FIELD_CLASS ] )
+			->setItemUrl( $item[ Swedbank_Pay_Order_Item::FIELD_ITEM_URL ] )
+			->setImageUrl( $item[ Swedbank_Pay_Order_Item::FIELD_IMAGE_URL ] )
+			->setDescription( $item[ Swedbank_Pay_Order_Item::FIELD_DESCRIPTION ] )
+			->setQuantity( $item[ Swedbank_Pay_Order_Item::FIELD_QTY ] )
+			->setUnitPrice( $item[ Swedbank_Pay_Order_Item::FIELD_UNITPRICE ] )
+			->setQuantityUnit( $item[ Swedbank_Pay_Order_Item::FIELD_QTY_UNIT ] )
+			->setVatPercent( $item[ Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT ] )
+			->setAmount( $item[ Swedbank_Pay_Order_Item::FIELD_AMOUNT ] )
+			->setVatAmount( $item[ Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT ] );
 
-			$order_items->addItem($orderItem);
+			$order_items->addItem( $order_item );
 		}
 
 		$payment_order = new Paymentorder();
@@ -202,7 +202,8 @@ class Swedbank_Pay_Api {
 				apply_filters(
 					'swedbank_pay_payment_description',
 					sprintf(
-					/* translators: 1: order id */                    __('Order #%1$s', 'swedbank-pay-woocommerce-payments'),
+						/* translators: 1: order id */
+						__( 'Order #%1$s', 'swedbank-pay-woocommerce-payments' ),
 						$order->get_order_number()
 					),
 					$order
@@ -215,8 +216,11 @@ class Swedbank_Pay_Api {
 			->setDisablePaymentMenu( false )
 			->setUrls( $urlData )
 			->setPayeeInfo( $payeeInfo )
-			->setMetadata( $metadata )
-			->setOrderItems( $order_items );
+			->setMetadata( $metadata );
+
+		if ( ! $gateway->exclude_order_lines ) {
+			$payment_order->setOrderItems( $order_items );
+		}
 
 		$payment_order->setPayer( $this->get_payer( $order ) );
 
@@ -267,9 +271,9 @@ class Swedbank_Pay_Api {
 	public function request( $method, $url, $params = array() ) {
 		// Get rid of full url. There's should be an endpoint only.
 		if ( filter_var( $url, FILTER_VALIDATE_URL ) ) {
-			$parsed = parse_url($url);
-			$url = $parsed['path'];
-			if (!empty($parsed['query'])) {
+			$parsed = parse_url( $url );
+			$url    = $parsed['path'];
+			if ( ! empty( $parsed['query'] ) ) {
 				$url .= '?' . $parsed['query'];
 			}
 		}
@@ -303,10 +307,10 @@ class Swedbank_Pay_Api {
 			/** @var \SwedbankPay\Api\Response $response */
 			$client = $this->get_client()->request( $method, $url, $params );
 
-			//$codeClass = (int)($this->client->getResponseCode() / 100);
+			// $codeClass = (int)($this->client->getResponseCode() / 100);
 			$response_body = $client->getResponseBody();
-			$result = json_decode( $response_body, true );
-			$time = microtime( true ) - $start;
+			$result        = json_decode( $response_body, true );
+			$time          = microtime( true ) - $start;
 			$this->log(
 				WC_Log_Levels::DEBUG,
 				sprintf( '[%.4F] Response: %s', $time, $response_body )
@@ -315,7 +319,7 @@ class Swedbank_Pay_Api {
 			return $result;
 		} catch ( \SwedbankPay\Api\Client\Exception $exception ) {
 			$httpCode = (int) $this->get_client()->getResponseCode();
-			$time = microtime( true ) - $start;
+			$time     = microtime( true ) - $start;
 			$this->log(
 				WC_Log_Levels::DEBUG,
 				sprintf(
@@ -357,14 +361,14 @@ class Swedbank_Pay_Api {
 	/**
 	 * Fetch Payment Info.
 	 *
-	 * @param string $payment_id_url
+	 * @param string      $payment_id_url
 	 * @param string|null $expand
 	 *
 	 * @return Response
 	 * @deprecated Use request()
 	 */
 	public function fetch_payment_info( $payment_id_url, $expand = null ) {
-		if ($expand) {
+		if ( $expand ) {
 			$payment_id_url .= '?$expand=' . $expand;
 		}
 
@@ -385,7 +389,7 @@ class Swedbank_Pay_Api {
 	// @todo Check if captured fully
 	public function is_captured( $payment_id_url ) {
 		// Fetch transactions list
-		$result = $this->request( 'GET', $payment_id_url . '/financialtransactions' );
+		$result           = $this->request( 'GET', $payment_id_url . '/financialtransactions' );
 		$transactionsList = $result['financialTransactions']['financialTransactionsList'];
 
 		// Check if have captured transactions
@@ -436,8 +440,8 @@ class Swedbank_Pay_Api {
 			$transaction_number = $data['paid']['number'];
 		}
 
-		$result = $this->request( 'GET', $payment_order_id . '/financialtransactions' );
-		$transactions_list = $result['financialTransactions']['financialTransactionsList'] ?? [];
+		$result            = $this->request( 'GET', $payment_order_id . '/financialtransactions' );
+		$transactions_list = $result['financialTransactions']['financialTransactionsList'] ?? array();
 		// @todo Sort by "created" field using array_multisort
 		foreach ( $transactions_list as $transaction ) {
 			if ( $transaction_number === $transaction['number'] ) {
@@ -463,7 +467,7 @@ class Swedbank_Pay_Api {
 			);
 
 			$transaction = array(
-				'id'             => $payment_order_id . '/financialtransactions/' . uniqid('fake'),
+				'id'             => $payment_order_id . '/financialtransactions/' . uniqid( 'fake' ),
 				'created'        => date( 'Y-m-d H:i:s' ),
 				'updated'        => date( 'Y-m-d H:i:s' ),
 				'type'           => $data['paid']['transactionType'],
@@ -490,13 +494,13 @@ class Swedbank_Pay_Api {
 	 * Process Transaction.
 	 *
 	 * @param WC_Order $order
-	 * @param array $transaction
+	 * @param array    $transaction
 	 *
 	 * @return true|WP_Error
 	 */
 	public function process_transaction( WC_Order $order, array $transaction ) {
 		$transaction_id = $transaction['number'];
-		
+
 		// Reload order meta to ensure we have the latest changes and avoid conflicts from parallel scripts
 		$order->read_meta_data();
 
@@ -598,7 +602,7 @@ class Swedbank_Pay_Api {
 					$order,
 					'cancelled',
 					$transaction_id,
-					sprintf('Payment has been cancelled. Transaction: %s', $transaction_id)
+					sprintf( 'Payment has been cancelled. Transaction: %s', $transaction_id )
 				);
 
 				break;
@@ -665,7 +669,7 @@ class Swedbank_Pay_Api {
 				// @todo Prent duplicated Credit Memo creation (by backend, by admin, by transaction callback)
 				break;
 			default:
-				return new \WP_Error( sprintf('Error: Unknown type %s', $transaction['type']) );
+				return new \WP_Error( sprintf( 'Error: Unknown type %s', $transaction['type'] ) );
 		}
 
 		// Save transaction ID
@@ -684,8 +688,8 @@ class Swedbank_Pay_Api {
 	/**
 	 * Update Order Status.
 	 *
-	 * @param WC_Order $order
-	 * @param string $status
+	 * @param WC_Order    $order
+	 * @param string      $status
 	 * @param string|null $transaction_id
 	 * @param string|null $message
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -716,8 +720,8 @@ class Swedbank_Pay_Api {
 			case 'pending':
 				// Set pending
 				if ( ! $order->has_status( 'pending' ) ) {
-					$order->update_status('pending', $message );
-				} elseif ($message) {
+					$order->update_status( 'pending', $message );
+				} elseif ( $message ) {
 					$order->add_order_note( $message );
 				}
 
@@ -777,7 +781,7 @@ class Swedbank_Pay_Api {
 				if ( ! $order->is_paid() ) {
 					$order->update_status( 'failed', $message );
 				} elseif ( $message ) {
-					$order->add_order_note($message);
+					$order->add_order_note( $message );
 				}
 
 				$order->set_transaction_id( $transaction_id );
@@ -801,16 +805,16 @@ class Swedbank_Pay_Api {
 			return false;
 		}
 
-		if ( empty( $this->payment_orders[$payment_order_id] ) ) {
-			$this->payment_orders[$payment_order_id] = $this->request( 'GET', $payment_order_id );
+		if ( empty( $this->payment_orders[ $payment_order_id ] ) ) {
+			$this->payment_orders[ $payment_order_id ] = $this->request( 'GET', $payment_order_id );
 		}
 
-		if ( is_wp_error( $this->payment_orders[$payment_order_id] ) ) {
+		if ( is_wp_error( $this->payment_orders[ $payment_order_id ] ) ) {
 			return false;
 		}
 
-		return isset( $this->payment_orders[$payment_order_id]['paymentOrder']['remainingCaptureAmount'] )
-			   && (float) $this->payment_orders[$payment_order_id]['paymentOrder']['remainingCaptureAmount'] > 0.1;
+		return isset( $this->payment_orders[ $payment_order_id ]['paymentOrder']['remainingCaptureAmount'] )
+				&& (float) $this->payment_orders[ $payment_order_id ]['paymentOrder']['remainingCaptureAmount'] > 0.1;
 	}
 
 	/**
@@ -826,16 +830,16 @@ class Swedbank_Pay_Api {
 			return false;
 		}
 
-		if ( empty( $this->payment_orders[$payment_order_id] ) ) {
-			$this->payment_orders[$payment_order_id] = $this->request( 'GET', $payment_order_id );
+		if ( empty( $this->payment_orders[ $payment_order_id ] ) ) {
+			$this->payment_orders[ $payment_order_id ] = $this->request( 'GET', $payment_order_id );
 		}
 
-		if ( is_wp_error( $this->payment_orders[$payment_order_id] ) ) {
+		if ( is_wp_error( $this->payment_orders[ $payment_order_id ] ) ) {
 			return false;
 		}
 
-		return isset( $this->payment_orders[$payment_order_id]['paymentOrder']['remainingCancellationAmount'] )
-			   && (float)$this->payment_orders[$payment_order_id]['paymentOrder']['remainingCancellationAmount'] > 0.1;
+		return isset( $this->payment_orders[ $payment_order_id ]['paymentOrder']['remainingCancellationAmount'] )
+				&& (float) $this->payment_orders[ $payment_order_id ]['paymentOrder']['remainingCancellationAmount'] > 0.1;
 	}
 
 	/**
@@ -851,16 +855,16 @@ class Swedbank_Pay_Api {
 			return false;
 		}
 
-		if ( empty( $this->payment_orders[$payment_order_id] ) ) {
-			$this->payment_orders[$payment_order_id] = $this->request( 'GET', $payment_order_id );
+		if ( empty( $this->payment_orders[ $payment_order_id ] ) ) {
+			$this->payment_orders[ $payment_order_id ] = $this->request( 'GET', $payment_order_id );
 		}
 
-		if ( is_wp_error( $this->payment_orders[$payment_order_id] ) ) {
+		if ( is_wp_error( $this->payment_orders[ $payment_order_id ] ) ) {
 			return false;
 		}
 
-		return isset( $this->payment_orders[$payment_order_id]['paymentOrder']['remainingReversalAmount'] )
-			   && (float) $this->payment_orders[$payment_order_id]['paymentOrder']['remainingReversalAmount'] > 0.1;
+		return isset( $this->payment_orders[ $payment_order_id ]['paymentOrder']['remainingReversalAmount'] )
+				&& (float) $this->payment_orders[ $payment_order_id ]['paymentOrder']['remainingReversalAmount'] > 0.1;
 	}
 
 	/**
@@ -869,10 +873,10 @@ class Swedbank_Pay_Api {
 	 * @return array
 	 */
 	private function get_host_urls( $urls ) {
-		$result = [];
+		$result = array();
 		foreach ( $urls as $url ) {
 			if ( filter_var( $url, FILTER_VALIDATE_URL ) ) {
-				$parsed = parse_url( $url );
+				$parsed   = parse_url( $url );
 				$result[] = sprintf( '%s://%s', $parsed['scheme'], $parsed['host'] );
 			}
 		}
@@ -884,7 +888,7 @@ class Swedbank_Pay_Api {
 	 * Capture Checkout.
 	 *
 	 * @param WC_Order $order
-	 * @param array $items
+	 * @param array    $items
 	 *
 	 * @return \WP_Error|array
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -908,27 +912,27 @@ class Swedbank_Pay_Api {
 		$order_items = new OrderItemsCollection();
 
 		// Recalculate amount and VAT amount
-		$amount = 0;
+		$amount     = 0;
 		$vat_amount = 0;
-		foreach ($items as $item) {
-			$amount += $item[Swedbank_Pay_Order_Item::FIELD_AMOUNT];
-			$vat_amount += $item[Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT];
+		foreach ( $items as $item ) {
+			$amount     += $item[ Swedbank_Pay_Order_Item::FIELD_AMOUNT ];
+			$vat_amount += $item[ Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT ];
 
 			$order_item = new OrderItem();
 			$order_item
-				->setReference( $item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] )
-				->setName( $item[Swedbank_Pay_Order_Item::FIELD_NAME] )
-				->setType( $item[Swedbank_Pay_Order_Item::FIELD_TYPE] )
-				->setItemClass( $item[Swedbank_Pay_Order_Item::FIELD_CLASS] )
-				->setItemUrl( $item[Swedbank_Pay_Order_Item::FIELD_ITEM_URL] )
-				->setImageUrl( $item[Swedbank_Pay_Order_Item::FIELD_IMAGE_URL] )
-				->setDescription( $item[Swedbank_Pay_Order_Item::FIELD_DESCRIPTION] )
-				->setQuantity( $item[Swedbank_Pay_Order_Item::FIELD_QTY] )
-				->setUnitPrice( $item[Swedbank_Pay_Order_Item::FIELD_UNITPRICE] )
-				->setQuantityUnit( $item[Swedbank_Pay_Order_Item::FIELD_QTY_UNIT] )
-				->setVatPercent( $item[Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT] )
-				->setAmount( $item[Swedbank_Pay_Order_Item::FIELD_AMOUNT] )
-				->setVatAmount( $item[Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT] );
+				->setReference( $item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] )
+				->setName( $item[ Swedbank_Pay_Order_Item::FIELD_NAME ] )
+				->setType( $item[ Swedbank_Pay_Order_Item::FIELD_TYPE ] )
+				->setItemClass( $item[ Swedbank_Pay_Order_Item::FIELD_CLASS ] )
+				->setItemUrl( $item[ Swedbank_Pay_Order_Item::FIELD_ITEM_URL ] )
+				->setImageUrl( $item[ Swedbank_Pay_Order_Item::FIELD_IMAGE_URL ] )
+				->setDescription( $item[ Swedbank_Pay_Order_Item::FIELD_DESCRIPTION ] )
+				->setQuantity( $item[ Swedbank_Pay_Order_Item::FIELD_QTY ] )
+				->setUnitPrice( $item[ Swedbank_Pay_Order_Item::FIELD_UNITPRICE ] )
+				->setQuantityUnit( $item[ Swedbank_Pay_Order_Item::FIELD_QTY_UNIT ] )
+				->setVatPercent( $item[ Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT ] )
+				->setAmount( $item[ Swedbank_Pay_Order_Item::FIELD_AMOUNT ] )
+				->setVatAmount( $item[ Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT ] );
 
 			$order_items->addItem( $order_item );
 		}
@@ -951,7 +955,7 @@ class Swedbank_Pay_Api {
 
 		$requestService = new TransactionCaptureV3( $transaction );
 		$requestService->setClient( $this->get_client() )
-			->setPaymentOrderId($payment_order_id);
+			->setPaymentOrderId( $payment_order_id );
 
 		try {
 			/** @var ResponseServiceInterface $responseService */
@@ -966,7 +970,7 @@ class Swedbank_Pay_Api {
 
 			// Save transaction
 			$transaction = $result['capture']['transaction'];
-			$gateway = swedbank_pay_get_payment_method( $order );
+			$gateway     = swedbank_pay_get_payment_method( $order );
 			$gateway->transactions->import( $transaction, $order->get_id() );
 
 			$this->process_transaction( $order, $transaction );
@@ -1007,9 +1011,9 @@ class Swedbank_Pay_Api {
 			);
 
 		$transaction = new TransactionObject();
-		$transaction->setTransaction($transaction_data);
+		$transaction->setTransaction( $transaction_data );
 
-		$requestService = new TransactionCancelV3($transaction);
+		$requestService = new TransactionCancelV3( $transaction );
 		$requestService->setClient( $this->get_client() )
 			->setPaymentOrderId( $payment_order_id );
 
@@ -1055,7 +1059,7 @@ class Swedbank_Pay_Api {
 	 * Refund amount for an order
 	 *
 	 * @param WC_Order $order The order object
-	 * @param float $amount The amount to refund
+	 * @param float    $amount The amount to refund
 	 *
 	 * @return TransactionObject|\WP_Error Returns the refunded transaction object or WP_Error on failure
 	 * @throws ClientException
@@ -1065,7 +1069,6 @@ class Swedbank_Pay_Api {
 		if ( empty( $payment_order_id ) ) {
 			return new \WP_Error( 0, 'Unable to get the payment order ID' );
 		}
-
 
 		$payee_refrence = apply_filters(
 			'swedbank_pay_payee_reference',
@@ -1085,7 +1088,7 @@ class Swedbank_Pay_Api {
 
 		$requestService = new TransactionReversalV3( $transaction );
 		$requestService->setClient( $this->get_client() )
-					   ->setPaymentOrderId( $payment_order_id );
+						->setPaymentOrderId( $payment_order_id );
 
 		try {
 			/** @var ResponseServiceInterface $responseService */
@@ -1107,7 +1110,7 @@ class Swedbank_Pay_Api {
 			$this->process_transaction( $order, $transaction );
 
 			return $transaction;
-		} catch (ClientException $e) {
+		} catch ( ClientException $e ) {
 			$this->log(
 				WC_Log_Levels::DEBUG,
 				$requestService->getClient()->getDebugInfo()
@@ -1129,7 +1132,7 @@ class Swedbank_Pay_Api {
 	 * Refund Checkout.
 	 *
 	 * @param WC_Order $order
-	 * @param array $items
+	 * @param array    $items
 	 *
 	 * @return \WP_Error|array
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -1152,27 +1155,27 @@ class Swedbank_Pay_Api {
 		$order_items = new OrderItemsCollection();
 
 		// Recalculate amount and VAT amount
-		$amount = 0;
+		$amount     = 0;
 		$vat_amount = 0;
-		foreach ($items as $item) {
-			$amount += $item[Swedbank_Pay_Order_Item::FIELD_AMOUNT];
-			$vat_amount += $item[Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT];
+		foreach ( $items as $item ) {
+			$amount     += $item[ Swedbank_Pay_Order_Item::FIELD_AMOUNT ];
+			$vat_amount += $item[ Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT ];
 
 			$order_item = new OrderItem();
 			$order_item
-				->setReference( $item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] )
-				->setName( $item[Swedbank_Pay_Order_Item::FIELD_NAME] )
-				->setType( $item[Swedbank_Pay_Order_Item::FIELD_TYPE] )
-				->setItemClass( $item[Swedbank_Pay_Order_Item::FIELD_CLASS] )
-				->setItemUrl( $item[Swedbank_Pay_Order_Item::FIELD_ITEM_URL] )
-				->setImageUrl( $item[Swedbank_Pay_Order_Item::FIELD_IMAGE_URL] )
-				->setDescription( $item[Swedbank_Pay_Order_Item::FIELD_DESCRIPTION] )
-				->setQuantity( $item[Swedbank_Pay_Order_Item::FIELD_QTY] )
-				->setUnitPrice( $item[Swedbank_Pay_Order_Item::FIELD_UNITPRICE] )
-				->setQuantityUnit( $item[Swedbank_Pay_Order_Item::FIELD_QTY_UNIT] )
-				->setVatPercent( $item[Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT] )
-				->setAmount( $item[Swedbank_Pay_Order_Item::FIELD_AMOUNT] )
-				->setVatAmount( $item[Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT] );
+				->setReference( $item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] )
+				->setName( $item[ Swedbank_Pay_Order_Item::FIELD_NAME ] )
+				->setType( $item[ Swedbank_Pay_Order_Item::FIELD_TYPE ] )
+				->setItemClass( $item[ Swedbank_Pay_Order_Item::FIELD_CLASS ] )
+				->setItemUrl( $item[ Swedbank_Pay_Order_Item::FIELD_ITEM_URL ] )
+				->setImageUrl( $item[ Swedbank_Pay_Order_Item::FIELD_IMAGE_URL ] )
+				->setDescription( $item[ Swedbank_Pay_Order_Item::FIELD_DESCRIPTION ] )
+				->setQuantity( $item[ Swedbank_Pay_Order_Item::FIELD_QTY ] )
+				->setUnitPrice( $item[ Swedbank_Pay_Order_Item::FIELD_UNITPRICE ] )
+				->setQuantityUnit( $item[ Swedbank_Pay_Order_Item::FIELD_QTY_UNIT ] )
+				->setVatPercent( $item[ Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT ] )
+				->setAmount( $item[ Swedbank_Pay_Order_Item::FIELD_AMOUNT ] )
+				->setVatAmount( $item[ Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT ] );
 
 			$order_items->addItem( $order_item );
 		}
@@ -1196,7 +1199,7 @@ class Swedbank_Pay_Api {
 
 		$requestService = new TransactionReversalV3( $transaction );
 		$requestService->setClient( $this->get_client() )
-					   ->setPaymentOrderId( $payment_order_id );
+						->setPaymentOrderId( $payment_order_id );
 
 		try {
 			/** @var ResponseServiceInterface $responseService */
@@ -1218,7 +1221,7 @@ class Swedbank_Pay_Api {
 			$this->process_transaction( $order, $transaction );
 
 			return $transaction;
-		} catch (ClientException $e) {
+		} catch ( ClientException $e ) {
 			$this->log(
 				WC_Log_Levels::DEBUG,
 				$requestService->getClient()->getDebugInfo()
@@ -1263,7 +1266,7 @@ class Swedbank_Pay_Api {
 			array_merge(
 				$context,
 				array(
-					'source' => 'payex_checkout',
+					'source'  => 'payex_checkout',
 					'_legacy' => true,
 				)
 			)
@@ -1290,12 +1293,12 @@ class Swedbank_Pay_Api {
 					'swedbank_pay_payee_reference',
 					swedbank_pay_generate_payee_reference( $order->get_id() )
 				),
-				'payeeId' => $gateway->payee_id,
-				'payeeName' => apply_filters(
+				'payeeId'        => $gateway->payee_id,
+				'payeeName'      => apply_filters(
 					'swedbank_pay_payee_name',
-					get_bloginfo('name'),
+					get_bloginfo( 'name' ),
 					$gateway->id
-				)
+				),
 			)
 		);
 	}
@@ -1306,14 +1309,13 @@ class Swedbank_Pay_Api {
 	 * @param WC_Order $order
 	 * @return PaymentorderPayer
 	 */
-	private function get_payer( WC_Order $order )
-	{
+	private function get_payer( WC_Order $order ) {
 		$payer = new PaymentorderPayer();
 		$payer->setPayerReference( $this->get_customer_uuid( $order ) );
 		$payer->setFirstName( $order->get_billing_first_name() )
-			  ->setLastName( $order->get_billing_last_name() )
-			  ->setEmail( $order->get_billing_email() )
-			  ->setMsisdn( str_replace( ' ', '', $order->get_billing_phone() ) );
+				->setLastName( $order->get_billing_last_name() )
+				->setEmail( $order->get_billing_email() )
+				->setMsisdn( str_replace( ' ', '', $order->get_billing_phone() ) );
 
 		// Does an order need shipping?
 		$needs_shipping = false;
@@ -1362,9 +1364,9 @@ class Swedbank_Pay_Api {
 		}
 
 		$client->setAccessToken( $this->access_token )
-			   ->setPayeeId( $this->payee_id )
-			   ->setMode( $this->mode === self::MODE_TEST ? Client::MODE_TEST : Client::MODE_PRODUCTION )
-			   ->setUserAgent( $user_agent );
+				->setPayeeId( $this->payee_id )
+				->setMode( $this->mode === self::MODE_TEST ? Client::MODE_TEST : Client::MODE_PRODUCTION )
+				->setUserAgent( $user_agent );
 
 		return $client;
 	}
@@ -1375,7 +1377,7 @@ class Swedbank_Pay_Api {
 	 * @return string
 	 */
 	private function get_initiating_system_user_agent() {
-		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		include_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		$plugins = get_plugins();
 		foreach ( $plugins as $file => $plugin ) {
@@ -1402,7 +1404,7 @@ class Swedbank_Pay_Api {
 		}
 
 		$message = isset( $response_body['detail'] ) ? $response_body['detail'] : '';
-		if ( isset( $response_body['problems'] ) && count( $response_body['problems'] ) > 0) {
+		if ( isset( $response_body['problems'] ) && count( $response_body['problems'] ) > 0 ) {
 			foreach ( $response_body['problems'] as $problem ) {
 				// Specify error message for invalid phone numbers. It's such fields like:
 				// Payment.Cardholder.Msisdn
@@ -1410,7 +1412,7 @@ class Swedbank_Pay_Api {
 				// Payment.Cardholder.WorkPhoneNumber
 				// Payment.Cardholder.BillingAddress.Msisdn
 				// Payment.Cardholder.ShippingAddress.Msisdn
-				if ( ( strpos( $problem['name'], 'Msisdn' ) !== false) ||
+				if ( ( strpos( $problem['name'], 'Msisdn' ) !== false ) ||
 					strpos( $problem['name'], 'HomePhoneNumber' ) !== false ||
 					strpos( $problem['name'], 'WorkPhoneNumber' ) !== false
 				) {
@@ -1446,7 +1448,7 @@ class Swedbank_Pay_Api {
 	private function calculate_vat_amount( array $items ) {
 		$vat_amount = 0;
 		foreach ( $items as $item ) {
-			$vat_amount += $item[Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT];
+			$vat_amount += $item[ Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT ];
 		}
 
 		return $vat_amount;

--- a/includes/class-swedbank-pay-instant-capture.php
+++ b/includes/class-swedbank-pay-instant-capture.php
@@ -107,8 +107,8 @@ class Swedbank_Pay_Instant_Capture {
 			$captured = array();
 			foreach ( $items as $item ) {
 				$captured[] = array(
-					Swedbank_Pay_Order_Item::FIELD_REFERENCE => $item[Swedbank_Pay_Order_Item::FIELD_REFERENCE],
-					Swedbank_Pay_Order_Item::FIELD_QTY => $item[Swedbank_Pay_Order_Item::FIELD_QTY]
+					Swedbank_Pay_Order_Item::FIELD_REFERENCE => $item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ],
+					Swedbank_Pay_Order_Item::FIELD_QTY => $item[ Swedbank_Pay_Order_Item::FIELD_QTY ],
 				);
 			}
 
@@ -150,7 +150,7 @@ class Swedbank_Pay_Instant_Capture {
 				$image = wc_placeholder_img_src( 'full' );
 			}
 
-			if ( null === parse_url( $image, PHP_URL_SCHEME ) &&
+			if ( null === wp_parse_url( $image, PHP_URL_SCHEME ) &&
 				mb_substr( $image, 0, mb_strlen( WP_CONTENT_URL ), 'UTF-8' ) === WP_CONTENT_URL
 			) {
 				$image = wp_guess_url() . $image;
@@ -182,19 +182,19 @@ class Swedbank_Pay_Instant_Capture {
 			) {
 				$items[] = array(
 					// The field Reference must match the regular expression '[\\w-]*'
-					Swedbank_Pay_Order_Item::FIELD_REFERENCE   => $product_reference,
-					Swedbank_Pay_Order_Item::FIELD_NAME        => ! empty( $product_name ) ? $product_name : '-',
-					Swedbank_Pay_Order_Item::FIELD_TYPE        => Swedbank_Pay_Order_Item::TYPE_PRODUCT,
-					Swedbank_Pay_Order_Item::FIELD_CLASS       => $product_class,
-					Swedbank_Pay_Order_Item::FIELD_ITEM_URL    => $order_item->get_product()->get_permalink(),
-					Swedbank_Pay_Order_Item::FIELD_IMAGE_URL   => $image,
+					Swedbank_Pay_Order_Item::FIELD_REFERENCE => $product_reference,
+					Swedbank_Pay_Order_Item::FIELD_NAME   => ! empty( $product_name ) ? $product_name : '-',
+					Swedbank_Pay_Order_Item::FIELD_TYPE   => Swedbank_Pay_Order_Item::TYPE_PRODUCT,
+					Swedbank_Pay_Order_Item::FIELD_CLASS  => $product_class,
+					Swedbank_Pay_Order_Item::FIELD_ITEM_URL => $order_item->get_product()->get_permalink(),
+					Swedbank_Pay_Order_Item::FIELD_IMAGE_URL => $image,
 					Swedbank_Pay_Order_Item::FIELD_DESCRIPTION => $order_item->get_name(),
-					Swedbank_Pay_Order_Item::FIELD_QTY         => $qty,
-					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT    => 'pcs',
-					Swedbank_Pay_Order_Item::FIELD_UNITPRICE   => round( $price_with_tax / $qty * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_QTY    => $qty,
+					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT => 'pcs',
+					Swedbank_Pay_Order_Item::FIELD_UNITPRICE => round( $price_with_tax / $qty * 100 ),
 					Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT => round( $tax_percent * 100 ),
-					Swedbank_Pay_Order_Item::FIELD_AMOUNT      => round( $price_with_tax * 100 ),
-					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT  => round( $tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_AMOUNT => round( $price_with_tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT => round( $tax * 100 ),
 				);
 
 				continue;
@@ -203,19 +203,19 @@ class Swedbank_Pay_Instant_Capture {
 			) {
 				$items[] = array(
 					// The field Reference must match the regular expression '[\\w-]*'
-					Swedbank_Pay_Order_Item::FIELD_REFERENCE   => $product_reference,
-					Swedbank_Pay_Order_Item::FIELD_NAME        => ! empty( $product_name ) ? $product_name : '-',
-					Swedbank_Pay_Order_Item::FIELD_TYPE        => Swedbank_Pay_Order_Item::TYPE_PRODUCT,
-					Swedbank_Pay_Order_Item::FIELD_CLASS       => $product_class,
-					Swedbank_Pay_Order_Item::FIELD_ITEM_URL    => $order_item->get_product()->get_permalink(),
-					Swedbank_Pay_Order_Item::FIELD_IMAGE_URL   => $image,
+					Swedbank_Pay_Order_Item::FIELD_REFERENCE => $product_reference,
+					Swedbank_Pay_Order_Item::FIELD_NAME   => ! empty( $product_name ) ? $product_name : '-',
+					Swedbank_Pay_Order_Item::FIELD_TYPE   => Swedbank_Pay_Order_Item::TYPE_PRODUCT,
+					Swedbank_Pay_Order_Item::FIELD_CLASS  => $product_class,
+					Swedbank_Pay_Order_Item::FIELD_ITEM_URL => $order_item->get_product()->get_permalink(),
+					Swedbank_Pay_Order_Item::FIELD_IMAGE_URL => $image,
 					Swedbank_Pay_Order_Item::FIELD_DESCRIPTION => $order_item->get_name(),
-					Swedbank_Pay_Order_Item::FIELD_QTY         => $qty,
-					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT    => 'pcs',
-					Swedbank_Pay_Order_Item::FIELD_UNITPRICE   => round( $price_with_tax / $qty * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_QTY    => $qty,
+					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT => 'pcs',
+					Swedbank_Pay_Order_Item::FIELD_UNITPRICE => round( $price_with_tax / $qty * 100 ),
 					Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT => round( $tax_percent * 100 ),
-					Swedbank_Pay_Order_Item::FIELD_AMOUNT      => round( $price_with_tax * 100 ),
-					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT  => round( $tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_AMOUNT => round( $price_with_tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT => round( $tax * 100 ),
 				);
 
 				continue;
@@ -224,19 +224,19 @@ class Swedbank_Pay_Instant_Capture {
 			) {
 				$items[] = array(
 					// The field Reference must match the regular expression '[\\w-]*'
-					Swedbank_Pay_Order_Item::FIELD_REFERENCE   => $product_reference,
-					Swedbank_Pay_Order_Item::FIELD_NAME        => ! empty( $product_name ) ? $product_name : '-',
-					Swedbank_Pay_Order_Item::FIELD_TYPE        => Swedbank_Pay_Order_Item::TYPE_PRODUCT,
-					Swedbank_Pay_Order_Item::FIELD_CLASS       => $product_class,
-					Swedbank_Pay_Order_Item::FIELD_ITEM_URL    => $order_item->get_product()->get_permalink(),
-					Swedbank_Pay_Order_Item::FIELD_IMAGE_URL   => $image,
+					Swedbank_Pay_Order_Item::FIELD_REFERENCE => $product_reference,
+					Swedbank_Pay_Order_Item::FIELD_NAME   => ! empty( $product_name ) ? $product_name : '-',
+					Swedbank_Pay_Order_Item::FIELD_TYPE   => Swedbank_Pay_Order_Item::TYPE_PRODUCT,
+					Swedbank_Pay_Order_Item::FIELD_CLASS  => $product_class,
+					Swedbank_Pay_Order_Item::FIELD_ITEM_URL => $order_item->get_product()->get_permalink(),
+					Swedbank_Pay_Order_Item::FIELD_IMAGE_URL => $image,
 					Swedbank_Pay_Order_Item::FIELD_DESCRIPTION => $order_item->get_name(),
-					Swedbank_Pay_Order_Item::FIELD_QTY         => $qty,
-					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT    => 'pcs',
-					Swedbank_Pay_Order_Item::FIELD_UNITPRICE   => round( $price_with_tax / $qty * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_QTY    => $qty,
+					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT => 'pcs',
+					Swedbank_Pay_Order_Item::FIELD_UNITPRICE => round( $price_with_tax / $qty * 100 ),
 					Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT => round( $tax_percent * 100 ),
-					Swedbank_Pay_Order_Item::FIELD_AMOUNT      => round( $price_with_tax * 100 ),
-					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT  => round( $tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_AMOUNT => round( $price_with_tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT => round( $tax * 100 ),
 				);
 
 				continue;
@@ -253,19 +253,19 @@ class Swedbank_Pay_Instant_Capture {
 				$shipping_method   = trim( $order->get_shipping_method() );
 
 				$items[] = array(
-					Swedbank_Pay_Order_Item::FIELD_REFERENCE   => 'shipping',
-					Swedbank_Pay_Order_Item::FIELD_NAME        => ! empty( $shipping_method ) ? $shipping_method : __(
+					Swedbank_Pay_Order_Item::FIELD_REFERENCE => 'shipping',
+					Swedbank_Pay_Order_Item::FIELD_NAME   => ! empty( $shipping_method ) ? $shipping_method : __(
 						'Shipping',
 						'woocommerce'
 					),
-					Swedbank_Pay_Order_Item::FIELD_TYPE        => Swedbank_Pay_Order_Item::TYPE_SHIPPING,
-					Swedbank_Pay_Order_Item::FIELD_CLASS       => 'ProductGroup1',
-					Swedbank_Pay_Order_Item::FIELD_QTY         => 1,
-					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT    => 'pcs',
-					Swedbank_Pay_Order_Item::FIELD_UNITPRICE   => round( $shipping_with_tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_TYPE   => Swedbank_Pay_Order_Item::TYPE_SHIPPING,
+					Swedbank_Pay_Order_Item::FIELD_CLASS  => 'ProductGroup1',
+					Swedbank_Pay_Order_Item::FIELD_QTY    => 1,
+					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT => 'pcs',
+					Swedbank_Pay_Order_Item::FIELD_UNITPRICE => round( $shipping_with_tax * 100 ),
 					Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT => round( $tax_percent * 100 ),
-					Swedbank_Pay_Order_Item::FIELD_AMOUNT      => round( $shipping_with_tax * 100 ),
-					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT  => round( $tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_AMOUNT => round( $shipping_with_tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT => round( $tax * 100 ),
 				);
 			}
 		}
@@ -280,16 +280,16 @@ class Swedbank_Pay_Instant_Capture {
 				$tax_percent  = ( $tax > 0 ) ? round( 100 / ( $fee / $tax ) ) : 0;
 
 				$items[] = array(
-					Swedbank_Pay_Order_Item::FIELD_REFERENCE   => 'fee',
-					Swedbank_Pay_Order_Item::FIELD_NAME        => $order_fee->get_name(),
-					Swedbank_Pay_Order_Item::FIELD_TYPE        => Swedbank_Pay_Order_Item::TYPE_OTHER,
-					Swedbank_Pay_Order_Item::FIELD_CLASS       => 'ProductGroup1',
-					Swedbank_Pay_Order_Item::FIELD_QTY         => 1,
-					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT    => 'pcs',
-					Swedbank_Pay_Order_Item::FIELD_UNITPRICE   => round( $fee_with_tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_REFERENCE => 'fee',
+					Swedbank_Pay_Order_Item::FIELD_NAME   => $order_fee->get_name(),
+					Swedbank_Pay_Order_Item::FIELD_TYPE   => Swedbank_Pay_Order_Item::TYPE_OTHER,
+					Swedbank_Pay_Order_Item::FIELD_CLASS  => 'ProductGroup1',
+					Swedbank_Pay_Order_Item::FIELD_QTY    => 1,
+					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT => 'pcs',
+					Swedbank_Pay_Order_Item::FIELD_UNITPRICE => round( $fee_with_tax * 100 ),
 					Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT => round( $tax_percent * 100 ),
-					Swedbank_Pay_Order_Item::FIELD_AMOUNT      => round( $fee_with_tax * 100 ),
-					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT  => round( $tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_AMOUNT => round( $fee_with_tax * 100 ),
+					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT => round( $tax * 100 ),
 				);
 			}
 		}
@@ -347,16 +347,16 @@ class Swedbank_Pay_Instant_Capture {
 					$discount          = round( -1 * ( $amount / ( 1 + (float) $rate_aux ) ), 2 );
 
 					$items[] = array(
-						Swedbank_Pay_Order_Item::FIELD_REFERENCE   => 'gift_card_' . esc_html( $code ),
-						Swedbank_Pay_Order_Item::FIELD_NAME        => __( 'Gift card: ' . esc_html( $code ), 'yith-woocommerce-gift-cards' ),
-						Swedbank_Pay_Order_Item::FIELD_TYPE        => Swedbank_Pay_Order_Item::TYPE_DISCOUNT,
-						Swedbank_Pay_Order_Item::FIELD_CLASS       => 'ProductGroup1',
-						Swedbank_Pay_Order_Item::FIELD_QTY         => 1,
-						Swedbank_Pay_Order_Item::FIELD_QTY_UNIT    => 'pcs',
-						Swedbank_Pay_Order_Item::FIELD_UNITPRICE   => round( 100 * $discount_with_tax ),
+						Swedbank_Pay_Order_Item::FIELD_REFERENCE => 'gift_card_' . esc_html( $code ),
+						Swedbank_Pay_Order_Item::FIELD_NAME => __( 'Gift card: ' . esc_html( $code ), 'yith-woocommerce-gift-cards' ),
+						Swedbank_Pay_Order_Item::FIELD_TYPE => Swedbank_Pay_Order_Item::TYPE_DISCOUNT,
+						Swedbank_Pay_Order_Item::FIELD_CLASS => 'ProductGroup1',
+						Swedbank_Pay_Order_Item::FIELD_QTY => 1,
+						Swedbank_Pay_Order_Item::FIELD_QTY_UNIT => 'pcs',
+						Swedbank_Pay_Order_Item::FIELD_UNITPRICE => round( 100 * $discount_with_tax ),
 						Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT => 100 * round( 100 * $rate_aux ),
-						Swedbank_Pay_Order_Item::FIELD_AMOUNT      => round( 100 * $discount_with_tax ),
-						Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT  => 100 * round( $discount_with_tax - $discount )
+						Swedbank_Pay_Order_Item::FIELD_AMOUNT => round( 100 * $discount_with_tax ),
+						Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT => 100 * round( $discount_with_tax - $discount ),
 					);
 				}
 			}

--- a/includes/class-swedbank-pay-payment-actions.php
+++ b/includes/class-swedbank-pay-payment-actions.php
@@ -56,18 +56,18 @@ class Swedbank_Pay_Payment_Actions {
 			// Remove captured items from order items list
 			foreach ( $order_lines as $key => &$order_item ) {
 				foreach ( $captured as &$captured_item ) {
-					if ( $order_item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] ===
-						 $captured_item[Swedbank_Pay_Order_Item::FIELD_REFERENCE]
+					if ( $order_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] ===
+						$captured_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ]
 					) {
 						$unit_vat = $order_item[Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT] / $order_item[Swedbank_Pay_Order_Item::FIELD_QTY]; //phpcs:ignore
-						$order_item[Swedbank_Pay_Order_Item::FIELD_QTY] -= $captured_item[Swedbank_Pay_Order_Item::FIELD_QTY];
+						$order_item[ Swedbank_Pay_Order_Item::FIELD_QTY ]     -= $captured_item[ Swedbank_Pay_Order_Item::FIELD_QTY ];
 						$order_item[Swedbank_Pay_Order_Item::FIELD_AMOUNT] = $order_item[Swedbank_Pay_Order_Item::FIELD_QTY] * $order_item[Swedbank_Pay_Order_Item::FIELD_UNITPRICE]; //phpcs:ignore
 						$order_item[Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT] = $order_item[Swedbank_Pay_Order_Item::FIELD_QTY] * $unit_vat; //phpcs:ignore
 
-						$captured_item[Swedbank_Pay_Order_Item::FIELD_QTY] += $order_item[Swedbank_Pay_Order_Item::FIELD_QTY];
+						$captured_item[ Swedbank_Pay_Order_Item::FIELD_QTY ] += $order_item[ Swedbank_Pay_Order_Item::FIELD_QTY ];
 
-						if ( 0 === $order_item[Swedbank_Pay_Order_Item::FIELD_QTY] ) {
-							unset( $order_lines[$key] );
+						if ( 0 === $order_item[ Swedbank_Pay_Order_Item::FIELD_QTY ] ) {
+							unset( $order_lines[ $key ] );
 						}
 					}
 				}
@@ -95,9 +95,9 @@ class Swedbank_Pay_Payment_Actions {
 		foreach ( $order_lines as $captured_line ) {
 			$is_found = false;
 			foreach ( $current_items as &$current_item ) {
-				if ( $current_item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] === $captured_line[Swedbank_Pay_Order_Item::FIELD_REFERENCE] ) {
+				if ( $current_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] === $captured_line[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] ) {
 					// Update
-					$current_item[Swedbank_Pay_Order_Item::FIELD_QTY] += $captured_line[Swedbank_Pay_Order_Item::FIELD_QTY];
+					$current_item[ Swedbank_Pay_Order_Item::FIELD_QTY ] += $captured_line[ Swedbank_Pay_Order_Item::FIELD_QTY ];
 					$is_found = true;
 
 					break;
@@ -105,17 +105,17 @@ class Swedbank_Pay_Payment_Actions {
 			}
 
 			if ( ! $is_found ) {
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_NAME] );
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_TYPE] );
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_CLASS] );
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_ITEM_URL] );
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_IMAGE_URL] );
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_DESCRIPTION] );
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_UNITPRICE] );
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_QTY_UNIT] );
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT] );
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_AMOUNT] );
-				unset( $captured_line[Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_NAME ] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_TYPE ] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_CLASS ] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_ITEM_URL ] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_IMAGE_URL ] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_DESCRIPTION ] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_UNITPRICE ] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_QTY_UNIT ] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT ] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_AMOUNT ] );
+				unset( $captured_line[ Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT ] );
 
 				$current_items[] = $captured_line;
 			}
@@ -150,7 +150,7 @@ class Swedbank_Pay_Payment_Actions {
 	 * Refund payment amount.
 	 *
 	 * @param WC_Order $order The order object.
-	 * @param float $amount The amount to refund.
+	 * @param float    $amount The amount to refund.
 	 *
 	 * @return \WP_Error|array The refund result.
 	 */
@@ -175,8 +175,8 @@ class Swedbank_Pay_Payment_Actions {
 	 * Perform Refund.
 	 *
 	 * @param \WC_Order $order
-	 * @param array $lines
-	 * @param array $items
+	 * @param array     $lines
+	 * @param array     $items
 	 * @param $reason
 	 *
 	 * @return \WP_Error|array
@@ -191,10 +191,10 @@ class Swedbank_Pay_Payment_Actions {
 
 		// Filter items
 		foreach ( $lines as $item_id => $line ) {
-			$qty = (int) $line['qty'];
-			$refund_total  = (float) $line['refund_total'];
+			$qty          = (int) $line['qty'];
+			$refund_total = (float) $line['refund_total'];
 			if ( $qty === 0 || $refund_total <= 0.01 ) {
-				unset( $lines[$item_id] );
+				unset( $lines[ $item_id ] );
 			}
 		}
 
@@ -223,8 +223,8 @@ class Swedbank_Pay_Payment_Actions {
 				$refund_tax += (float) $refund_tax_value;
 			}
 
-			$refund_total  = (float) $line['refund_total'];
-			$tax_percent   = ( $refund_total > 0 && $refund_tax > 0 ) ?
+			$refund_total = (float) $line['refund_total'];
+			$tax_percent  = ( $refund_total > 0 && $refund_tax > 0 ) ?
 				round( 100 / ( $refund_total / $refund_tax ) ) : 0;
 
 			if ( 'excl' === get_option( 'woocommerce_tax_display_shop' ) ) {
@@ -310,8 +310,8 @@ class Swedbank_Pay_Payment_Actions {
 						$image = wc_placeholder_img_src( 'full' );
 					}
 
-					if ( null === parse_url( $image, PHP_URL_SCHEME ) &&
-						 mb_substr( $image, 0, mb_strlen( WP_CONTENT_URL ), 'UTF-8' ) === WP_CONTENT_URL
+					if ( null === wp_parse_url( $image, PHP_URL_SCHEME ) &&
+						mb_substr( $image, 0, mb_strlen( WP_CONTENT_URL ), 'UTF-8' ) === WP_CONTENT_URL
 					) {
 						$image = wp_guess_url() . $image;
 					}
@@ -408,7 +408,7 @@ class Swedbank_Pay_Payment_Actions {
 		if ( $create_credit_memo ) {
 			$amount = 0;
 			foreach ( $items as $item ) {
-				$amount += ( $item[Swedbank_Pay_Order_Item::FIELD_AMOUNT] / 100 );
+				$amount += ( $item[ Swedbank_Pay_Order_Item::FIELD_AMOUNT ] / 100 );
 			}
 
 			$refund = wc_create_refund(
@@ -418,14 +418,14 @@ class Swedbank_Pay_Payment_Actions {
 					'reason'         => $reason,
 					'line_items'     => $lines,
 					'refund_payment' => false,
-					'restock_items'  => true
+					'restock_items'  => true,
 				)
 			);
 			if ( is_wp_error( $refund ) ) {
 				$order->add_order_note(
 					sprintf(
 						'Refund could not be created. Error: %s',
-						join('; ', $refund->get_error_messages() )
+						join( '; ', $refund->get_error_messages() )
 					)
 				);
 			}
@@ -438,7 +438,7 @@ class Swedbank_Pay_Payment_Actions {
 	 * Validate order lines.
 	 *
 	 * @param WC_Order $order
-	 * @param array $lines
+	 * @param array    $lines
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -472,8 +472,8 @@ class Swedbank_Pay_Payment_Actions {
 						/** @var WC_Order_Item_Product $item */
 						foreach ( $captured as $order_item ) {
 							$sku = $item->get_product()->get_sku();
-							if ($order_item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] === $sku &&
-								$qty > $order_item[Swedbank_Pay_Order_Item::FIELD_QTY]
+							if ( $order_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] === $sku &&
+								$qty > $order_item[ Swedbank_Pay_Order_Item::FIELD_QTY ]
 							) {
 								throw new \Exception(
 									sprintf(
@@ -490,7 +490,7 @@ class Swedbank_Pay_Payment_Actions {
 						/** @var WC_Order_Item_Shipping $item */
 						$isCaptured = false;
 						foreach ( $captured as $order_item ) {
-							if ( $order_item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] === 'shipping' ) {
+							if ( $order_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] === 'shipping' ) {
 								$isCaptured = true;
 								break;
 							}
@@ -511,7 +511,7 @@ class Swedbank_Pay_Payment_Actions {
 						/** @var WC_Order_Item_Fee $item */
 						$isCaptured = false;
 						foreach ( $captured as $order_item ) {
-							if ( $order_item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] === 'fee' ) {
+							if ( $order_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] === 'fee' ) {
 								$isCaptured = true;
 								break;
 							}
@@ -534,7 +534,7 @@ class Swedbank_Pay_Payment_Actions {
 	}
 
 	private function save_refunded_items( WC_Order $order, array $lines ) {
-		$order_lines = [];
+		$order_lines = array();
 		foreach ( $lines as $item_id => $line ) {
 			$qty = (int) $line['qty'];
 			if ( $qty < 1 ) {
@@ -560,7 +560,7 @@ class Swedbank_Pay_Payment_Actions {
 
 			$order_lines[] = array(
 				Swedbank_Pay_Order_Item::FIELD_REFERENCE => $reference,
-				Swedbank_Pay_Order_Item::FIELD_QTY => $qty
+				Swedbank_Pay_Order_Item::FIELD_QTY       => $qty,
 			);
 		}
 
@@ -570,8 +570,8 @@ class Swedbank_Pay_Payment_Actions {
 		if ( count( $current_items ) > 0 ) {
 			foreach ( $current_items as &$current_item ) {
 				foreach ( $order_lines as $order_line ) {
-					if ( $order_line[Swedbank_Pay_Order_Item::FIELD_REFERENCE] === $current_item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] ) {
-						$current_item[Swedbank_Pay_Order_Item::FIELD_QTY] += $order_line[Swedbank_Pay_Order_Item::FIELD_QTY];
+					if ( $order_line[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] === $current_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] ) {
+						$current_item[ Swedbank_Pay_Order_Item::FIELD_QTY ] += $order_line[ Swedbank_Pay_Order_Item::FIELD_QTY ];
 						break;
 					} else {
 						$current_items[] = $order_line;

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -7,6 +7,7 @@ use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Background_Queue;
 use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Transactions;
 use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Instant_Capture;
 use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Payment_Actions;
+use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Scheduler;
 
 /**
  * @SuppressWarnings(PHPMD.CamelCaseClassName)
@@ -30,36 +31,42 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 	/**
 	 * Access Token
+	 *
 	 * @var string
 	 */
 	public $access_token = '';
 
 	/**
 	 * Payee Id
+	 *
 	 * @var string
 	 */
 	public $payee_id = '';
 
 	/**
 	 * Test Mode
+	 *
 	 * @var string
 	 */
 	public $testmode = 'no';
 
 	/**
 	 * Debug Mode
+	 *
 	 * @var string
 	 */
 	public $debug = 'yes';
 
 	/**
 	 * IP Checking
+	 *
 	 * @var string
 	 */
 	public $ip_check = 'yes';
 
 	/**
 	 * Locale
+	 *
 	 * @var string
 	 */
 	public $culture = 'en-US';
@@ -73,6 +80,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 	/**
 	 * Instant Capture
+	 *
 	 * @var array
 	 */
 	public $instant_capture = array();
@@ -89,6 +97,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 	/**
 	 * Swedbank Pay ip addresses
+	 *
 	 * @var array
 	 */
 	public $gateway_ip_addresses = array( '91.132.170.1' );
@@ -105,18 +114,19 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 	/**
 	 * Init
+	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 */
 	public function __construct() {
 		$this->transactions = Swedbank_Pay_Transactions::instance();
 
-		$this->id           = 'payex_checkout';
-		$this->has_fields   = true;
-		$this->method_title = __( 'Swedbank Pay Payment Menu', 'swedbank-pay-woocommerce-checkout' );
+		$this->id                 = 'payex_checkout';
+		$this->has_fields         = true;
+		$this->method_title       = __( 'Swedbank Pay Payment Menu', 'swedbank-pay-woocommerce-checkout' );
 		$this->method_description = __( 'Provides the Swedbank Pay Payment Menu for WooCommerce', 'swedbank-pay-woocommerce-checkout' );
-		//$this->icon         = apply_filters( 'woocommerce_swedbank_pay_payments_icon', plugins_url( '/assets/images/checkout.svg', dirname( __FILE__ ) ) );
-		$this->supports     = array(
+		// $this->icon         = apply_filters( 'woocommerce_swedbank_pay_payments_icon', plugins_url( '/assets/images/checkout.svg', dirname( __FILE__ ) ) );
+		$this->supports = array(
 			'products',
 			'refunds',
 		);
@@ -178,6 +188,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 	/**
 	 * Initialise Settings Form Fields
+	 *
 	 * @return string|void
 	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
@@ -198,7 +209,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				'label'   => __( 'Enable Swedbank Pay Test Mode', 'swedbank-pay-woocommerce-checkout' ),
 				'default' => $this->testmode,
 			),
-			'title'            => array(
+			'title'           => array(
 				'title'       => __( 'Title', 'swedbank-pay-woocommerce-checkout' ),
 				'type'        => 'text',
 				'description' => __(
@@ -224,7 +235,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				'custom_attributes' => array(
 					'required' => 'required',
 				),
-				'sanitize_callback' => function( $value ) {
+				'sanitize_callback' => function ( $value ) {
 					if ( empty( $value ) ) {
 						throw new Exception( __( '"Payee Id" field can\'t be empty.', 'swedbank-pay-woocommerce-checkout' ) );
 					}
@@ -240,7 +251,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				'custom_attributes' => array(
 					'required' => 'required',
 				),
-				'sanitize_callback' => function( $value ) {
+				'sanitize_callback' => function ( $value ) {
 					if ( empty( $value ) ) {
 						throw new Exception( __( '"Access Token" field can\'t be empty.', 'swedbank-pay-woocommerce-checkout' ) );
 					}
@@ -289,7 +300,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				'description'       => __( 'The URL that will be used for showing the customer logo. Must be a picture with maximum 50px height and 400px width. Require https.', 'swedbank-pay-woocommerce-checkout' ),
 				'desc_tip'          => true,
 				'default'           => '',
-				'sanitize_callback' => function( $value ) {
+				'sanitize_callback' => function ( $value ) {
 					if ( ! empty( $value ) ) {
 						if ( ! filter_var( $value, FILTER_VALIDATE_URL ) ) {
 							throw new Exception( __( 'Logo Url is invalid.', 'swedbank-pay-woocommerce-checkout' ) );
@@ -301,7 +312,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 					return $value;
 				},
 			),
-			'autocomplete'        => array(
+			'autocomplete'    => array(
 				'title'   => __( 'Automatic order status', 'swedbank-pay-woocommerce-checkout' ),
 				'type'    => 'checkbox',
 				'label'   => __( 'Set order in completed status immediately after payment', 'swedbank-pay-woocommerce-checkout' ),
@@ -400,7 +411,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			return;
 		}
 
-		$this->api->log( WC_Log_Levels::INFO, __METHOD__, [ $order_id ] );
+		$this->api->log( WC_Log_Levels::INFO, __METHOD__, array( $order_id ) );
 		$is_finalized     = $order->get_meta( '_payex_finalized' );
 		$payment_order_id = $order->get_meta( '_payex_paymentorder_id' );
 		if ( empty( $is_finalized ) && $payment_order_id ) {
@@ -418,7 +429,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 		}
 
 		// Capture payment is applicable
-		if ( 'yes' === $this->autocomplete && $order->has_status( 'on-hold' )  ) {
+		if ( 'yes' === $this->autocomplete && $order->has_status( 'on-hold' ) ) {
 			$result = $this->payment_actions_handler->capture_payment( $order );
 			if ( ! is_wp_error( $result ) ) {
 				$order->payment_complete();
@@ -480,12 +491,13 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 		return array(
 			'result'   => 'success',
-			'redirect' => $redirect_url
+			'redirect' => $redirect_url,
 		);
 	}
 
 	/**
 	 * IPN Callback
+	 *
 	 * @return void
 	 * @throws \Exception
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -509,7 +521,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			sprintf( 'Incoming Callback. Post data: %s', var_export( $raw_body, true ) )
 		);
 
-		// Check IP address of Incoming Callback
+		// Check IP address of Incoming Callback.
 		if ( 'yes' === $this->ip_check ) {
 			if ( ! in_array(
 				WC_Geolocation::get_ip_address(),
@@ -525,7 +537,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			}
 		}
 
-		// Decode raw body
+		// Decode raw body.
 		$data = json_decode( $raw_body, true );
 		if ( JSON_ERROR_NONE !== json_last_error() ) {
 			throw new Exception( 'Invalid webhook data' );
@@ -545,7 +557,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				throw new Exception( 'A provided order key has been invalid.' );
 			}
 
-			// Validate fields
+			// Validate fields.
 			if ( ! isset( $data['paymentOrder'] ) || ! isset( $data['paymentOrder']['id'] ) ) {
 				throw new \Exception( 'Error: Invalid paymentOrder value' );
 			}
@@ -554,19 +566,27 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 				throw new \Exception( 'Error: Invalid transaction number' );
 			}
 
-			// Create Background Process Task
-			$background_process = new Swedbank_Pay_Background_Queue();
-			$background_process->push_to_queue(
+			// Schedule the payment for later processing.
+			$schedule_id = as_schedule_single_action(
+				time() + 30,
+				Swedbank_Pay_Scheduler::ACTION_ID,
 				array(
 					'payment_method_id' => $this->id,
 					'webhook_data'      => $raw_body,
 				)
 			);
-			$background_process->save();
+
+			if ( 0 === $schedule_id ) {
+				$this->api->log(
+					WC_Log_Levels::ERROR,
+					sprintf( 'Error: Unable to schedule a task for %s', $this->id )
+				);
+				throw new \Exception( 'Unable to schedule a task.' );
+			}
 
 			$this->api->log(
 				WC_Log_Levels::INFO,
-				sprintf( 'Incoming Callback: Task enqueued. Transaction ID: %s', $data['transaction']['number'] )
+				sprintf( 'Incoming Callback: payment scheduled as %s. Transaction ID: %s', $schedule_id, $data['transaction']['number'] )
 			);
 		} catch ( \Exception $e ) {
 			$this->api->log( WC_Log_Levels::INFO, sprintf( 'Incoming Callback: %s', $e->getMessage() ) );
@@ -581,8 +601,8 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	 * If the gateway declares 'refunds' support, this will allow it to refund
 	 * a passed in amount.
 	 *
-	 * @param int $order_id
-	 * @param float $amount
+	 * @param int    $order_id
+	 * @param float  $amount
 	 * @param string $reason
 	 *
 	 * @return  bool|wp_error True or false based on success, or a WP_Error object
@@ -627,7 +647,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			// Refund by items
 			$result = $this->payment_actions_handler->refund_payment( $order, $lines, $reason, false );
 			if ( is_wp_error( $result ) ) {
-				return new WP_Error( 'refund', join('; ', $result->get_error_messages() ) );
+				return new WP_Error( 'refund', join( '; ', $result->get_error_messages() ) );
 			}
 
 			$order->update_meta_data( '_sb_refund_mode', 'items' );
@@ -639,7 +659,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 		// Refund by amount
 		$result = $this->payment_actions_handler->refund_payment_amount( $order, $amount );
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error( 'refund', join('; ', $result->get_error_messages() ) );
+			return new WP_Error( 'refund', join( '; ', $result->get_error_messages() ) );
 		}
 
 		$order->update_meta_data( '_sb_refund_mode', 'amount' );
@@ -651,7 +671,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	/**
 	 * Override payment method title.
 	 *
-	 * @param string $value
+	 * @param string   $value
 	 * @param WC_Order $order
 	 *
 	 * @return string
@@ -713,7 +733,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * @param bool $is_editable
+	 * @param bool     $is_editable
 	 * @param WC_Order $order
 	 *
 	 * @return bool

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -161,12 +161,12 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 		$this->instant_capture     = $this->settings['instant_capture'] ?? $this->instant_capture;
 		$this->terms_url           = $this->settings['terms_url'] ?? get_site_url();
 		$this->autocomplete        = $this->settings['autocomplete'] ?? 'no';
-		$this->exclude_order_lines = $this->settings['exclude_order_lines'] ?? 'no';
+		$this->exclude_order_lines = wc_string_to_bool( $this->settings['exclude_order_lines'] ?? 'no' );
 
 		// TermsOfServiceUrl contains unsupported scheme value http in Only https supported.
 		if ( ! filter_var( $this->terms_url, FILTER_VALIDATE_URL ) ) {
 			$this->terms_url = '';
-		} elseif ( 'https' !== parse_url( $this->terms_url, PHP_URL_SCHEME ) ) {
+		} elseif ( 'https' !== wp_parse_url( $this->terms_url, PHP_URL_SCHEME ) ) {
 			$this->terms_url = '';
 		}
 

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -310,7 +310,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 					if ( ! empty( $value ) ) {
 						if ( ! filter_var( $value, FILTER_VALIDATE_URL ) ) {
 							throw new Exception( __( 'Logo Url is invalid.', 'swedbank-pay-woocommerce-checkout' ) );
-						} elseif ( 'https' !== parse_url( $value, PHP_URL_SCHEME ) ) {
+						} elseif ( 'https' !== wp_parse_url( $value, PHP_URL_SCHEME ) ) {
 							throw new Exception( __( 'Logo Url should use https scheme.', 'swedbank-pay-woocommerce-checkout' ) );
 						}
 					}

--- a/includes/class-swedbank-pay-plugin.php
+++ b/includes/class-swedbank-pay-plugin.php
@@ -92,20 +92,21 @@ class Swedbank_Pay_Plugin {
 	 * @SuppressWarnings(PHPMD.UnusedLocalVariable)
 	 */
 	public function includes() {
-		$vendors_dir = dirname( __FILE__ ) . '/../vendor';
+		$vendors_dir = __DIR__ . '/../vendor';
 		require_once $vendors_dir . '/autoload.php';
-		require_once( dirname( __FILE__ ) . '/functions.php' );
-		require_once( dirname( __FILE__ ) . '/interface-swedbank-pay-order-item.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-transactions.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-api.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-instant-capture.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-payment-actions.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-admin.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-thankyou.php' );
-		require_once( dirname( __FILE__ ) . '/class-swedbank-pay-intl-tel.php' );
+		require_once __DIR__ . '/functions.php';
+		require_once __DIR__ . '/interface-swedbank-pay-order-item.php';
+		require_once __DIR__ . '/class-swedbank-pay-transactions.php';
+		require_once __DIR__ . '/class-swedbank-pay-api.php';
+		require_once __DIR__ . '/class-swedbank-pay-instant-capture.php';
+		require_once __DIR__ . '/class-swedbank-pay-payment-actions.php';
+		require_once __DIR__ . '/class-swedbank-pay-admin.php';
+		require_once __DIR__ . '/class-swedbank-pay-thankyou.php';
+		require_once __DIR__ . '/class-swedbank-pay-intl-tel.php';
+		require_once __DIR__ . '/class-swedbank-pay-scheduler.php';
 
 		if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
-			require_once( dirname( __FILE__ ) . '/class-swedbank-pay-blocks-support.php' );
+			require_once __DIR__ . '/class-swedbank-pay-blocks-support.php';
 		}
 	}
 
@@ -155,8 +156,9 @@ class Swedbank_Pay_Plugin {
 	 * WooCommerce Init
 	 */
 	public function woocommerce_init() {
-		include_once( dirname( __FILE__ ) . '/class-swedbank-pay-background-queue.php' );
+		include_once __DIR__ . '/class-swedbank-pay-background-queue.php';
 		self::$background_process = new Swedbank_Pay_Background_Queue();
+		Swedbank_Pay_Scheduler::get_instance();
 	}
 
 	/**
@@ -173,7 +175,7 @@ class Swedbank_Pay_Plugin {
 
 		if ( ! isset( $px_gateways[ $class_name ] ) ) {
 			// Initialize instance
-			$gateway = new $class_name;
+			$gateway = new $class_name();
 
 			if ( $gateway ) {
 				$px_gateways[] = $class_name;
@@ -205,7 +207,7 @@ class Swedbank_Pay_Plugin {
 	/**
 	 * Billing phone.
 	 *
-	 * @param string $billing_phone
+	 * @param string   $billing_phone
 	 * @param WC_Order $order
 	 *
 	 * @return string
@@ -301,6 +303,7 @@ class Swedbank_Pay_Plugin {
 
 	/**
 	 * Support Page
+	 *
 	 * @SuppressWarnings(PHPMD.Superglobals)
 	 */
 	public static function support_page() {
@@ -313,7 +316,7 @@ class Swedbank_Pay_Plugin {
 				'message'  => isset( $_GET['message'] ) ? sanitize_text_field( wp_unslash( $_GET['message'] ) ) : null, // WPCS: input var ok, CSRF ok.
 			),
 			'',
-			dirname( __FILE__ ) . '/../templates/'
+			__DIR__ . '/../templates/'
 		);
 	}
 
@@ -326,7 +329,7 @@ class Swedbank_Pay_Plugin {
 		}
 
 		// Run Database Update
-		include_once( dirname( __FILE__ ) . '/class-swedbank-pay-update.php' );
+		include_once __DIR__ . '/class-swedbank-pay-update.php';
 		Swedbank_Pay_Update::update();
 
 		echo esc_html__( 'Upgrade finished.', 'swedbank-pay-woocommerce-checkout' );
@@ -459,6 +462,7 @@ class Swedbank_Pay_Plugin {
 
 	/**
 	 * Send support message
+	 *
 	 * @SuppressWarnings(PHPMD.Superglobals)
 	 * @SuppressWarnings(PHPMD.ErrorControlOperator)
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -586,6 +590,7 @@ class Swedbank_Pay_Plugin {
 
 	/**
 	 * Handle a custom '_payex_paymentorder_id' query var to get orders with the '_payex_paymentorder_id' meta.
+	 *
 	 * @see https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query
 	 * @param array $query - Args for WP_Query.
 	 * @param array $query_vars - Query vars from WC_Order_Query.
@@ -593,10 +598,10 @@ class Swedbank_Pay_Plugin {
 	 */
 	public function handle_custom_query_var( $query, $query_vars ) {
 		if ( ! empty( $query_vars['_payex_paymentorder_id'] ) ) {
-			$query['meta_query'][] = [
-				'key' => '_payex_paymentorder_id',
+			$query['meta_query'][] = array(
+				'key'   => '_payex_paymentorder_id',
 				'value' => esc_attr( $query_vars['_payex_paymentorder_id'] ),
-			];
+			);
 		}
 
 		return $query;
@@ -609,12 +614,12 @@ class Swedbank_Pay_Plugin {
 	 */
 	public function woocommerce_blocks_support() {
 		if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
-			require_once( dirname( __FILE__ ) . '/class-swedbank-pay-blocks-support.php' );
+			require_once __DIR__ . '/class-swedbank-pay-blocks-support.php';
 
 			add_action(
 				'woocommerce_blocks_payment_method_type_registration',
-				function( PaymentMethodRegistry $payment_method_registry ) {
-					$payment_method_registry->register( new Swedbank_Pay_Blocks_Support );
+				function ( PaymentMethodRegistry $payment_method_registry ) {
+					$payment_method_registry->register( new Swedbank_Pay_Blocks_Support() );
 				}
 			);
 		}

--- a/includes/class-swedbank-pay-scheduler.php
+++ b/includes/class-swedbank-pay-scheduler.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Swedbank Pay Scheduler Class.
+ * Handles scheduled tasks for Swedbank Pay.
+ *
+ * @package SwedbankPay\Checkout\WooCommerce
+ */
+
+namespace SwedbankPay\Checkout\WooCommerce;
+
+use WC_Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+
+/**
+ * Swedbank_Pay_Scheduler Class.
+ */
+class Swedbank_Pay_Scheduler {
+	public const ACTION_ID = 'swedbank_pay_scheduler_run';
+
+	/**
+	 * @var Swedbank_Pay_Scheduler
+	 */
+	private static $instance = null;
+
+	/**
+	 * Singleton pattern
+	 *
+	 * @return Swedbank_Pay_Scheduler
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Logger instance.
+	 *
+	 * @var WC_Logger
+	 */
+	private $logger;
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		$this->logger = \wc_get_logger();
+
+		add_action( 'swedbank_pay_scheduler_run', array( $this, 'run' ), 10, 2 );
+	}
+
+	/**
+	 * Log message.
+	 *
+	 * @param string $message The message to log.
+	 */
+	private function log( $message ) {
+		$this->logger->info( $message, array( 'source' => 'swedbank_pay_queue' ) );
+	}
+
+	/**
+	 * Code to execute for each item in the queue.
+	 *
+	 * @throws \Exception If the webhook data is invalid or if the order cannot be found.
+	 *
+	 * @param string $payment_method_id The payment method ID.
+	 * @param string $webhook_data The webhook data in JSON format.
+	 *
+	 * @return false|null
+	 */
+	public function run( $payment_method_id, $webhook_data ) {
+		$this->log( sprintf( 'Start task: %s', var_export( array( $payment_method_id, $webhook_data ), true ) ) );
+
+		try {
+			$payload = $webhook_data;
+			$data    = json_decode( $payload, true );
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
+				throw new \Exception( 'Invalid webhook data' );
+			}
+
+			if ( ! isset( $data['paymentOrder'] ) || ! isset( $data['paymentOrder']['id'] ) ) {
+				throw new \Exception( 'Error: Invalid paymentOrder value' );
+			}
+
+			if ( ! isset( $data['transaction'] ) || ! isset( $data['transaction']['number'] ) ) {
+				throw new \Exception( 'Error: Invalid transaction number' );
+			}
+
+			$transaction_number = $data['transaction']['number'];
+			$payment_order_id   = $data['paymentOrder']['id'];
+
+			// Get order by `orderReference`.
+			if ( isset( $data['orderReference'] ) ) {
+				$order = wc_get_order( $data['orderReference'] );
+				if ( ! $order ) {
+					throw new \Exception( 'Failed to find order: ' . $data['orderReference'] );
+				}
+
+				$this->log(
+					sprintf(
+						'[SCHEDULER]: Found order #%s by order reference %s.',
+						$order->get_id(),
+						$data['orderReference']
+					)
+				);
+			} else {
+				// Get Order by Payment Order Id.
+				$order = swedbank_pay_get_order( $payment_order_id );
+				if ( ! $order ) {
+					throw new \Exception( 'Failed to find order: ' . $payment_order_id );
+				}
+
+				$this->log( sprintf( '[SCHEDULER]: Found order #%s by payment Order ID %s.', $order->get_id(), $payment_order_id ) );
+			}
+
+			$gateway = swedbank_pay_get_payment_method( $order );
+			if ( ! $gateway ) {
+				throw new \Exception(
+					sprintf(
+						'Can\'t retrieve payment gateway instance: %s',
+						$payment_method_id
+					)
+				);
+			}
+
+			if ( ! property_exists( $gateway, 'api' ) ||
+				! in_array( $order->get_payment_method(), Swedbank_Pay_Plugin::PAYMENT_METHODS, true ) ) {
+				$this->log(
+					sprintf(
+						'[ERROR]: Order #%s has not been paid with the swedbank pay. Payment method: %s',
+						$order->get_id(),
+						$order->get_payment_method()
+					)
+				);
+
+				return false;
+			}
+
+			$transactions = (array) $order->get_meta( '_swedbank_pay_transactions' );
+			if ( in_array( $transaction_number, $transactions, true ) ) {
+				$this->log( sprintf( '[SCHEDULER]: Transaction #%s was processed before.', $transaction_number ) );
+				return false;
+			}
+		} catch ( \Exception $e ) {
+			$this->log( sprintf( '[ERROR]: Validation error: %s', $e->getMessage() ) );
+			return false;
+		}
+
+		// @todo Use https://developer.swedbankpay.com/checkout-v3/features/core/callback
+		$result = $gateway->api->finalize_payment( $order, $transaction_number );
+		if ( is_wp_error( $result ) ) {
+			$this->log( sprintf( '[ERROR]: %s', $result->get_error_message() ) );
+			return false;
+		}
+
+		return false;
+	}
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -73,6 +73,7 @@ function swedbank_pay_get_post_id_by_meta( $key, $value ) {
 
 /**
  * Get Order by Payment Order ID.
+ *
  * @uses woocommerce_order_data_store_cpt_get_orders_query hook
  * @param string $paymentOrderId
  *
@@ -81,11 +82,11 @@ function swedbank_pay_get_post_id_by_meta( $key, $value ) {
 function swedbank_pay_get_order( $paymentOrderId ) {
 	$orders = wc_get_orders(
 		array(
-			'_payex_paymentorder_id' => $paymentOrderId
+			'_payex_paymentorder_id' => $paymentOrderId,
 		)
 	);
 
-	foreach ($orders as $order) {
+	foreach ( $orders as $order ) {
 		return $order;
 	}
 
@@ -136,8 +137,8 @@ function swedbank_pay_get_order_lines( WC_Order $order ) {
 			$image = wc_placeholder_img_src( 'full' );
 		}
 
-		if ( null === parse_url( $image, PHP_URL_SCHEME ) &&
-			 mb_substr( $image, 0, mb_strlen( WP_CONTENT_URL ), 'UTF-8' ) === WP_CONTENT_URL
+		if ( null === wp_parse_url( $image, PHP_URL_SCHEME ) &&
+			mb_substr( $image, 0, mb_strlen( WP_CONTENT_URL ), 'UTF-8' ) === WP_CONTENT_URL
 		) {
 			$image = wp_guess_url() . $image;
 		}
@@ -172,7 +173,7 @@ function swedbank_pay_get_order_lines( WC_Order $order ) {
 			Swedbank_Pay_Order_Item::FIELD_ITEM_URL    => $order_item->get_product()->get_permalink(),
 			Swedbank_Pay_Order_Item::FIELD_IMAGE_URL   => $image,
 			Swedbank_Pay_Order_Item::FIELD_DESCRIPTION => $order_item->get_name(),
-			Swedbank_Pay_Order_Item::FIELD_QTY          => $qty,
+			Swedbank_Pay_Order_Item::FIELD_QTY         => $qty,
 			Swedbank_Pay_Order_Item::FIELD_QTY_UNIT    => 'pcs',
 			Swedbank_Pay_Order_Item::FIELD_UNITPRICE   => round( $price_with_tax / $qty * 100 ),
 			Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT => round( $tax_percent * 100 ),
@@ -280,16 +281,16 @@ function swedbank_pay_get_order_lines( WC_Order $order ) {
 				$discount          = round( -1 * ( $amount / ( 1 + (float) $rate_aux ) ), 2 );
 
 				$items[] = array(
-					Swedbank_Pay_Order_Item::FIELD_REFERENCE   => 'gift_card_' . esc_html( $code ),
-					Swedbank_Pay_Order_Item::FIELD_NAME        => __( 'Gift card: ' . esc_html( $code ), 'yith-woocommerce-gift-cards' ),
-					Swedbank_Pay_Order_Item::FIELD_TYPE        => Swedbank_Pay_Order_Item::TYPE_DISCOUNT,
-					Swedbank_Pay_Order_Item::FIELD_CLASS       => 'ProductGroup1',
-					Swedbank_Pay_Order_Item::FIELD_QTY         => 1,
-					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT    => 'pcs',
-					Swedbank_Pay_Order_Item::FIELD_UNITPRICE   => round( 100 * $discount_with_tax ),
+					Swedbank_Pay_Order_Item::FIELD_REFERENCE => 'gift_card_' . esc_html( $code ),
+					Swedbank_Pay_Order_Item::FIELD_NAME   => __( 'Gift card: ' . esc_html( $code ), 'yith-woocommerce-gift-cards' ),
+					Swedbank_Pay_Order_Item::FIELD_TYPE   => Swedbank_Pay_Order_Item::TYPE_DISCOUNT,
+					Swedbank_Pay_Order_Item::FIELD_CLASS  => 'ProductGroup1',
+					Swedbank_Pay_Order_Item::FIELD_QTY    => 1,
+					Swedbank_Pay_Order_Item::FIELD_QTY_UNIT => 'pcs',
+					Swedbank_Pay_Order_Item::FIELD_UNITPRICE => round( 100 * $discount_with_tax ),
 					Swedbank_Pay_Order_Item::FIELD_VAT_PERCENT => 100 * round( 100 * $rate_aux ),
-					Swedbank_Pay_Order_Item::FIELD_AMOUNT      => round( 100 * $discount_with_tax ),
-					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT  => 100 * round( $discount_with_tax - $discount )
+					Swedbank_Pay_Order_Item::FIELD_AMOUNT => round( 100 * $discount_with_tax ),
+					Swedbank_Pay_Order_Item::FIELD_VAT_AMOUNT => 100 * round( $discount_with_tax - $discount ),
 				);
 			}
 		}
@@ -308,7 +309,7 @@ function swedbank_pay_get_available_line_items_for_refund( WC_Order $order ) {
 	$refunded = empty( $refunded ) ? array() : (array) $refunded;
 
 	// Order lines
-	$lines = array();
+	$lines      = array();
 	$line_items = $order->get_items( array( 'line_item', 'shipping', 'fee' ) );
 	foreach ( $captured as $captured_item ) {
 		foreach ( $line_items as $item_id => $item ) {
@@ -347,13 +348,13 @@ function swedbank_pay_get_available_line_items_for_refund( WC_Order $order ) {
 			$row_price_with_tax = $order->get_line_total( $item, true, false );
 			$row_tax            = $row_price_with_tax - $row_price;
 
-			if ( $reference === $captured_item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] ) {
-				$qty = $captured_item[Swedbank_Pay_Order_Item::FIELD_QTY];
+			if ( $reference === $captured_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] ) {
+				$qty = $captured_item[ Swedbank_Pay_Order_Item::FIELD_QTY ];
 
 				// Exclude refunded items
 				foreach ( $refunded as $refunded_item ) {
-					if ( $reference === $refunded_item[Swedbank_Pay_Order_Item::FIELD_REFERENCE] ) {
-						$qty -= $refunded_item[Swedbank_Pay_Order_Item::FIELD_QTY];
+					if ( $reference === $refunded_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] ) {
+						$qty -= $refunded_item[ Swedbank_Pay_Order_Item::FIELD_QTY ];
 
 						break;
 					}
@@ -383,13 +384,13 @@ function swedbank_pay_get_available_line_items_for_refund( WC_Order $order ) {
 
 /**
  * @param WC_Order $order
- * @param float $amount
+ * @param float    $amount
  *
  * @return WC_Order_Refund|null
  */
 function swedbank_pay_get_last_refund( WC_Order $order, $amount ) {
 	$refunds = $order->get_refunds();
-	foreach ($refunds as $refund) {
+	foreach ( $refunds as $refund ) {
 		/** @var WC_Order_Refund $refund */
 		if ( round( $amount, 2 ) == round( $refund->get_amount(), 2 ) ) {
 			// Check the creation time
@@ -398,7 +399,7 @@ function swedbank_pay_get_last_refund( WC_Order $order, $amount ) {
 				return $refund;
 			}
 
-			if ( $created_at > ( new \WC_DateTime( '-10 minutes' ) ) && $created_at < ( new \WC_DateTime('now') ) ) {
+			if ( $created_at > ( new \WC_DateTime( '-10 minutes' ) ) && $created_at < ( new \WC_DateTime( 'now' ) ) ) {
 				return $refund;
 			}
 		}
@@ -416,7 +417,7 @@ function swedbank_pay_get_last_refund( WC_Order $order, $amount ) {
  */
 function swedbank_pay_generate_payee_reference( $order_id ) {
 	$arr = range( 'a', 'z' );
-	shuffle($arr);
+	shuffle( $arr );
 	$reference = $order_id . 'x' . substr( implode( '', $arr ), 0, 5 );
 
 	return apply_filters( 'swedbank_pay_payee_reference', $reference, $order_id );


### PR DESCRIPTION
A lot of changes are PHPCS-related (either automatic or manual). The changes relevant for this PR are as follows:

- `Swedbank_Pay_Api::initiate_purchase` where order lines are conditionally omitted. Note, the order lines collection must be created even if the order lines won't be included since it is used for calculating the total and VAT amount.
- the setting is added in `Swedbank_Pay_Payment_Gateway_Checkout::constructor`.

Other changes:
- `parse_url` → `wp_parse_url`.
- `json_encode` → `wp_json_encode`.
- simplified with `??`.
- use snake_case.

https://app.clickup.com/t/8699egy37