### PR TITLE
Changes default status for authorized and captured

### DIFF
--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -416,10 +416,12 @@ class Swedbank_Pay_Api {
 
 				break;
 			case self::TYPE_SALE:
+			case self::TYPE_CAPTURE:
+				// FIXME: Do we set to Completed even if partially captured?
 				$is_full_capture = false;
 
 				// Check if the payment was captured fully
-				// `remainingCaptureAmount` is missing if the payment was captured fully
+				// `remainingCaptureAmount` is missing if the payment was captured fully.
 				if ( ! isset( $payment_order['remainingCaptureAmount'] ) ) {
 					Swedbank_Pay()->logger()->debug(
 						sprintf(
@@ -434,11 +436,11 @@ class Swedbank_Pay_Api {
 					$is_full_capture = true;
 				}
 
-				// Update order status
+				// Update order status.
 				if ( $is_full_capture ) {
 					$this->update_order_status(
 						$order,
-						'processing',
+						'completed',
 						$transaction_id,
 						sprintf(
 							'Payment has been captured. Transaction: %s. Amount: %s',

--- a/includes/class-swedbank-pay-instant-capture.php
+++ b/includes/class-swedbank-pay-instant-capture.php
@@ -34,15 +34,15 @@ class Swedbank_Pay_Instant_Capture {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'woocommerce_order_status_on-hold', array( $this, 'maybe_capture_instantly' ), 50, 10 );
+		add_action( 'woocommerce_order_status_completed', array( $this, 'maybe_capture_instantly' ), 50, 10 );
 	}
 
 	/**
 	 * Maybe capture instantly.
 	 *
-	 * @param $order_id
+	 * @param $order_id The WooCommerce order ID.
 	 *
-	 * @throws \Exception
+	 * @throws \Exception If the capture fails.
 	 */
 	public function maybe_capture_instantly( $order_id ) {
 		$order          = wc_get_order( $order_id );
@@ -61,12 +61,12 @@ class Swedbank_Pay_Instant_Capture {
 			return;
 		}
 
-		// Disable this feature if "Autocomplete" is active
+		// Disable this feature if "Autocomplete" is active.
 		if ( 'yes' === $this->gateway->autocomplete ) {
 			return;
 		}
 
-		// Capture if possible
+		// Capture if possible.
 		if ( ! $this->gateway->api->is_captured( $payment_order_id ) ) {
 			try {
 				$this->instant_capture( $order );


### PR DESCRIPTION
- when authorized by Swedbank, the order status will now be determined by `payment_complete`. Previously, it was `'on-hold'`.
- when captured by Swedbank, the order will now be set to `'completed'`. Previously, it was `'processing'`.

https://app.clickup.com/t/8699m496z