### PR TITLE
Feature merchant portal link metabox

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,3 @@
+a.button.swedbank-pay-transaction-link {
+	margin: 10px 0 5px 0;
+}

--- a/includes/class-swedbank-pay-admin.php
+++ b/includes/class-swedbank-pay-admin.php
@@ -231,6 +231,13 @@ class Swedbank_Pay_Admin {
 				true
 			);
 
+			wp_register_style(
+				'swedbank-pay-admin-css',
+				plugin_dir_url( __FILE__ ) . '../assets/css/admin.css',
+				array(),
+				SWEDBANK_PAY_VERSION
+			);
+
 			// Localize the script.
 			$translation_array = array(
 				'ajax_url'  => admin_url( 'admin-ajax.php' ),
@@ -241,6 +248,7 @@ class Swedbank_Pay_Admin {
 			wp_localize_script( 'swedbank-pay-admin-js', 'SwedbankPay_Admin', $translation_array );
 
 			// Enqueued script with localized data.
+			wp_enqueue_style( 'swedbank-pay-admin-css' );
 			wp_enqueue_script( 'swedbank-pay-admin-js' );
 		}
 	}

--- a/templates/admin/payment-actions.php
+++ b/templates/admin/payment-actions.php
@@ -34,8 +34,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php $transaction_url = $gateway->get_transaction_url( $order ); ?>
 	<?php if ( $transaction_url ) : ?>
 		<a href="<?php echo esc_url( $transaction_url ); ?>"
-		   target="_blank"
-		   class="button button-secondary">
+			target="_blank"
+			class="button button-secondary swedbank-pay-transaction-link">
 			<?php esc_html_e( 'View in Merchant Portal', 'swedbank-pay-payment-menu' ); ?>
 		</a>
 		<br/>

--- a/templates/admin/payment-actions.php
+++ b/templates/admin/payment-actions.php
@@ -31,6 +31,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 			: </strong> <?php echo esc_html( $info['paid']['payeeReference'] ); ?>
 		<br/>
 	<?php endif; ?>
+	<?php $transaction_url = $gateway->get_transaction_url( $order ); ?>
+	<?php if ( $transaction_url ) : ?>
+		<a href="<?php echo esc_url( $transaction_url ); ?>"
+		   target="_blank"
+		   class="button button-secondary">
+			<?php esc_html_e( 'View in Merchant Portal', 'swedbank-pay-payment-menu' ); ?>
+		</a>
+		<br/>
+	<?php endif; ?>
+
 	<?php if ( $gateway->api->can_capture( $order ) ) : ?>
 		<button id="swedbank_pay_capture"
 				data-nonce="<?php echo esc_attr( wp_create_nonce( 'swedbank_pay' ) ); ?>"


### PR DESCRIPTION
Added an admin stylesheet to the code that @krokedilmartin wrote for displaying a merchant portal link in the order metabox.

**Question**: Should this be styled as a button though? Since it's a link without any action etc, should it not just be styled as a link?