### PR TITLE
Set culture using WP locale

### DIFF
--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -233,7 +233,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			'en_US',
 		);
 
-		$culture = $supported_cultures[ $locale ] ?? 'en_US';
+		$culture = in_array( $locale, $supported_cultures, true ) ? $locale : 'en_US';
 
 		// Format exceptions for locales that do not match the expected format, e.g. fi_FI for Finnish in Finland.
 		switch ( $culture ) {

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -162,7 +162,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 		$this->access_token                 = $this->settings['access_token'] ?? $this->access_token;
 		$this->payee_id                     = $this->settings['payee_id'] ?? $this->payee_id;
 		$this->testmode                     = $this->settings['testmode'] ?? $this->testmode;
-		$this->culture                      = $this->settings['culture'] ?? $this->culture;
+		$this->culture                      = self::locale_to_culture( get_locale() );
 		$this->logo_url                     = $this->settings['logo_url'] ?? $this->logo_url;
 		$this->instant_capture              = $this->settings['instant_capture'] ?? $this->instant_capture;
 		$this->terms_url                    = $this->settings['terms_url'] ?? get_site_url();
@@ -201,6 +201,37 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			->set_mode( wc_string_to_bool( $this->testmode ) ? Swedbank_Pay_Api::MODE_TEST : Swedbank_Pay_Api::MODE_LIVE );
 
 		$this->payment_actions_handler = new Swedbank_Pay_Payment_Actions( $this );
+	}
+
+	/**
+	 * Map a WordPress locale string to a Swedbank Pay culture code.
+	 *
+	 * @param string $locale WordPress locale, e.g. 'sv_SE'.
+	 * @return string Swedbank Pay culture code, e.g. 'sv-SE'. Falls back to 'en-US'.
+	 */
+	public static function locale_to_culture( string $locale ): string {
+		$map = array(
+			'da_DK' => 'da-DK',
+			'de_DE' => 'de-DE',
+			'de_AT' => 'de-DE',
+			'de_CH' => 'de-DE',
+			'es_ES' => 'es-ES',
+			'et'    => 'et-EE',
+			'et_EE' => 'et-EE',
+			'fi'    => 'fi-FI',
+			'fi_FI' => 'fi-FI',
+			'fr_FR' => 'fr-FR',
+			'fr_BE' => 'fr-FR',
+			'lt_LT' => 'lt-LT',
+			'lv'    => 'lv-LV',
+			'lv_LV' => 'lv-LV',
+			'nb_NO' => 'nb-NO',
+			'pl_PL' => 'pl-PL',
+			'ru_RU' => 'ru-RU',
+			'sv_SE' => 'sv-SE',
+		);
+
+		return $map[ $locale ] ?? 'en-US';
 	}
 
 	/**
@@ -285,25 +316,6 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 
 					return $value;
 				},
-			),
-			'culture'                     => array(
-				'title'       => __( 'Language', 'swedbank-pay-payment-menu' ),
-				'type'        => 'select',
-				'options'     => array(
-					'da-DK' => __( 'Danish', 'swedbank-pay-payment-menu' ),
-					'en-US' => __( 'English', 'swedbank-pay-payment-menu' ),
-					'et-EE' => __( 'Estonian', 'swedbank-pay-payment-menu' ),
-					'fi-FI' => __( 'Finnish', 'swedbank-pay-payment-menu' ),
-					'lt-LT' => __( 'Lithuanian', 'swedbank-pay-payment-menu' ),
-					'lv-LV' => __( 'Latvian', 'swedbank-pay-payment-menu' ),
-					'nb-NO' => __( 'Norwegian', 'swedbank-pay-payment-menu' ),
-					'sv-SE' => __( 'Swedish', 'swedbank-pay-payment-menu' ),
-				),
-				'description' => __(
-					'Language of pages displayed by Swedbank Pay during payment.',
-					'swedbank-pay-payment-menu'
-				),
-				'default'     => $this->culture,
 			),
 			'instant_capture'             => array(
 				'title'          => __( 'Instant Capture', 'swedbank-pay-payment-menu' ),

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -162,7 +162,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 		$this->access_token                 = $this->settings['access_token'] ?? $this->access_token;
 		$this->payee_id                     = $this->settings['payee_id'] ?? $this->payee_id;
 		$this->testmode                     = $this->settings['testmode'] ?? $this->testmode;
-		$this->culture                      = self::locale_to_culture( get_locale() );
+		$this->culture                      = self::locale_to_culture();
 		$this->logo_url                     = $this->settings['logo_url'] ?? $this->logo_url;
 		$this->instant_capture              = $this->settings['instant_capture'] ?? $this->instant_capture;
 		$this->terms_url                    = $this->settings['terms_url'] ?? get_site_url();
@@ -204,34 +204,47 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * Map a WordPress locale string to a Swedbank Pay culture code.
+	 * Convert WordPress locale to Swedbank Pay culture code.
 	 *
-	 * @param string $locale WordPress locale, e.g. 'sv_SE'.
-	 * @return string Swedbank Pay culture code, e.g. 'sv-SE'. Falls back to 'en-US'.
+	 * @return string Swedbank Pay culture code, e.g. 'sv-SE'.
 	 */
-	public static function locale_to_culture( string $locale ): string {
-		$map = array(
-			'da_DK' => 'da-DK',
-			'de_DE' => 'de-DE',
-			'de_AT' => 'de-DE',
-			'de_CH' => 'de-DE',
-			'es_ES' => 'es-ES',
-			'et'    => 'et-EE',
-			'et_EE' => 'et-EE',
-			'fi'    => 'fi-FI',
-			'fi_FI' => 'fi-FI',
-			'fr_FR' => 'fr-FR',
-			'fr_BE' => 'fr-FR',
-			'lt_LT' => 'lt-LT',
-			'lv'    => 'lv-LV',
-			'lv_LV' => 'lv-LV',
-			'nb_NO' => 'nb-NO',
-			'pl_PL' => 'pl-PL',
-			'ru_RU' => 'ru-RU',
-			'sv_SE' => 'sv-SE',
+	public static function locale_to_culture() {
+		$locale = get_locale();
+
+		$supported_cultures = array(
+			'da_DK',
+			'de_DE',
+			'de_AT',
+			'de_CH',
+			'es_ES',
+			'et',
+			'et_EE',
+			'fi',
+			'fi_FI',
+			'fr_FR',
+			'fr_BE',
+			'lt_LT',
+			'lv',
+			'lv_LV',
+			'nb_NO',
+			'pl_PL',
+			'ru_RU',
+			'sv_SE',
+			'en_US',
 		);
 
-		return $map[ $locale ] ?? 'en-US';
+		$culture = $supported_cultures[ $locale ] ?? 'en_US';
+
+		// Format exceptions for locales that do not match the expected format, e.g. fi_FI for Finnish in Finland.
+		switch ( $culture ) {
+			case 'fi':
+				$culture = 'fi_FI';
+				break;
+			default:
+				break;
+		}
+
+		return substr( str_replace( '_', '-', $culture ), 0, 5 );
 	}
 
 	/**

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -211,40 +211,16 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	public static function locale_to_culture() {
 		$locale = get_locale();
 
-		$supported_cultures = array(
-			'da_DK',
-			'de_DE',
-			'de_AT',
-			'de_CH',
-			'es_ES',
-			'et',
-			'et_EE',
-			'fi',
-			'fi_FI',
-			'fr_FR',
-			'fr_BE',
-			'lt_LT',
-			'lv',
-			'lv_LV',
-			'nb_NO',
-			'pl_PL',
-			'ru_RU',
-			'sv_SE',
-			'en_US',
-		);
-
-		$culture = in_array( $locale, $supported_cultures, true ) ? $locale : 'en_US';
-
 		// Format exceptions for locales that do not match the expected format, e.g. fi_FI for Finnish in Finland.
-		switch ( $culture ) {
+		switch ( $locale ) {
 			case 'fi':
-				$culture = 'fi_FI';
+				$locale = 'fi_FI';
 				break;
 			default:
 				break;
 		}
 
-		return substr( str_replace( '_', '-', $culture ), 0, 5 );
+		return substr( str_replace( '_', '-', $locale ), 0, 5 );
 	}
 
 	/**

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -216,6 +216,12 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			case 'fi':
 				$locale = 'fi_FI';
 				break;
+			case 'et':
+				$locale = 'et_EE';
+				break;
+			case 'lv':
+				$locale = 'lv_LV';
+				break;
 			default:
 				break;
 		}

--- a/src/CheckoutFlow/InlineEmbedded.php
+++ b/src/CheckoutFlow/InlineEmbedded.php
@@ -83,7 +83,7 @@ class InlineEmbedded extends CheckoutFlow {
 
 		$params = array(
 			'script_debug'     => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
-			'culture'          => $this->gateway->get_option( 'culture', 'en-US' ),
+			'culture'          => $this->gateway->culture,
 			'payment_complete' => $this->is_payment_complete,
 		);
 


### PR DESCRIPTION
Removes the language plugin setting, converts the current WordPress locale to a needed language code (fallback to `en-US`) and finally passes this as the `culture` to Swedbank Pay.

Code written by @krokedilmartin, tested with supported language (Swedish) which displays the payment iframe in Swedish, and non-supported language, which falls back to US english as expected without crashing.
