### PR TITLE
Resolve PHP warning "undefined array key"

### DIFF
--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -842,7 +842,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 					// Request failed.
 					return $value;
 				}
-				$instrument = $result['paid']['instrument'];
+				$instrument = $result['paid']['instrument'] ?? '';
 				$order->update_meta_data( '_swedbank_pay_payment_instrument', $instrument );
 				$order->save();
 


### PR DESCRIPTION
Resolves warning:
PHP Warning:  Undefined array key "instrument" in /var/www/html/wp-content/plugins/swedbank-pay-woocommerce-paymentmenu/includes/class-swedbank-pay-payment-gateway-checkout.php on line 845