### PR TITLE
Show description field not shown on woocommerce checkout page

### DIFF
--- a/src/CheckoutFlow/Redirect.php
+++ b/src/CheckoutFlow/Redirect.php
@@ -58,7 +58,16 @@ class Redirect extends CheckoutFlow {
 	 * @return void
 	 */
 	protected function payment_fields_content( $gateway_id = 'payex_checkout' ) {
-		$description = $this->gateway->get_option( 'description' );
+		$gateway = $this->gateway;
+
+		if ( ! empty( $gateway_id ) && function_exists( 'WC' ) && WC()->payment_gateways() ) {
+			$payment_gateways = WC()->payment_gateways()->payment_gateways();
+			if ( isset( $payment_gateways[ $gateway_id ] ) ) {
+				$gateway = $payment_gateways[ $gateway_id ];
+			}
+		}
+
+		$description = method_exists( $gateway, 'get_option' ) ? $gateway->get_option( 'description' ) : '';
 		if ( $description ) {
 			echo wp_kses_post( wpautop( wptexturize( $description ) ) );
 		}

--- a/src/CheckoutFlow/Redirect.php
+++ b/src/CheckoutFlow/Redirect.php
@@ -52,6 +52,19 @@ class Redirect extends CheckoutFlow {
 	}
 
 	/**
+	 * Output the payment fields content for the redirect flow.
+	 *
+	 * @param string $gateway_id The gateway ID.
+	 * @return void
+	 */
+	protected function payment_fields_content( $gateway_id = 'payex_checkout' ) {
+		$description = $this->gateway->get_option( 'description' );
+		if ( $description ) {
+			echo wp_kses_post( wpautop( wptexturize( $description ) ) );
+		}
+	}
+
+	/**
 	 * Process a subscription purchase.
 	 *
 	 * @param \WC_Order $order The WooCommerce order to be processed.


### PR DESCRIPTION
In version 4.3.0, a `payment_fields()` override was added to the gateway 
class to support the new inline embedded checkout flow. This override 
replaced WooCommerce's default implementation — which automatically renders 
`$this->description` — without carrying over that behavior to the Redirect 
flow.