### PR TITLE
Fix gateway description not showing on checkout and split instrument description setting not saving

### DIFF
--- a/src/CheckoutFlow/Redirect.php
+++ b/src/CheckoutFlow/Redirect.php
@@ -106,7 +106,7 @@ class Redirect extends CheckoutFlow {
 
 		$description = $gateway->get_description();
 		if ( ! empty( $description ) ) {
-			echo wpautop( wptexturize( $description ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo wp_kses_post( wpautop( wptexturize( $description ) ) );
 		}
 	}
 }

--- a/src/CheckoutFlow/Redirect.php
+++ b/src/CheckoutFlow/Redirect.php
@@ -86,4 +86,27 @@ class Redirect extends CheckoutFlow {
 			'redirect' => $result->getOperationByRel( 'redirect-checkout', 'href' ),
 		);
 	}
+
+	/**
+	 * Output the payment fields content for the handler.
+	 *
+	 * Mirrors WooCommerce's default WC_Payment_Gateway::payment_fields() behavior
+	 * by rendering the gateway description, which the gateway's payment_fields()
+	 * override no longer does on its own. When called from a split instrument
+	 * gateway, the per-instrument description is rendered instead of the main
+	 * gateway's description.
+	 *
+	 * @param string $gateway_id The gateway ID whose description should be rendered.
+	 *
+	 * @return void
+	 */
+	protected function payment_fields_content( $gateway_id = 'payex_checkout' ) {
+		$gateways = WC()->payment_gateways()->payment_gateways();
+		$gateway  = $gateways[ $gateway_id ] ?? $this->gateway;
+
+		$description = $gateway->get_description();
+		if ( ! empty( $description ) ) {
+			echo wpautop( wptexturize( $description ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+	}
 }

--- a/src/Gateways/SplitInstrumentGateway.php
+++ b/src/Gateways/SplitInstrumentGateway.php
@@ -50,6 +50,8 @@ class SplitInstrumentGateway extends \WC_Payment_Gateway {
 
 		$this->supports   = $instrument['supports'] ?? array( 'products', 'refunds' );
 		$this->has_fields = false; // False for now. Once we add support for embedded version, we will need to set this to true.
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes two related regressions affecting the payment method description on the
checkout page.

### 1. Description not displayed on checkout (Redirect flow)

In v4.3.0, a `payment_fields()` override was added to the gateway class to
support the new inline embedded checkout flow. This override replaced
WooCommerce's default `WC_Payment_Gateway::payment_fields()` — which
automatically renders `$this->description` — without carrying that behavior
over to the Redirect flow.

As a result, any text entered in the gateway's "Description" setting stopped
appearing under the payment method on the checkout page.

### 2. Split instrument gateway settings were silently discarded

While verifying the first fix with Separate Instruments enabled, saving the
"Description" field on an individual instrument (e.g. Card) had no effect:
WooCommerce displayed "Your settings have been saved" but the value was never
persisted.