### PR TITLE
Pass billing country code to Swedbank Pay in payer object

### DIFF
--- a/composer-dependencies.json
+++ b/composer-dependencies.json
@@ -2,7 +2,7 @@
   "require": {
     "php": ">=7.4",
     "ramsey/uuid": "^3.7",
-    "swedbank-pay/swedbank-pay-sdk-php": "dev-develop-v3.1-api",
+    "swedbank-pay/swedbank-pay-sdk-php": "dev-add-payer-country-code",
     "krokedil/support": "1.0.2"
   },
   "config": {

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "876f89e7b29e373655ea2e144da55806",
+    "content-hash": "744aae224012957628868616302c410d",
     "packages": [
         {
             "name": "krokedil/support",
@@ -214,16 +214,16 @@
         },
         {
             "name": "swedbank-pay/swedbank-pay-sdk-php",
-            "version": "dev-develop-v3.1-api",
+            "version": "dev-add-payer-country-code",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/swedbank-pay-sdk-php.git",
-                "reference": "715f8aa778bf012e37ffc16f619ff2125dd67d92"
+                "reference": "330b328a3d5ef67f395a48c0f00fd953b4c870be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/swedbank-pay-sdk-php/zipball/715f8aa778bf012e37ffc16f619ff2125dd67d92",
-                "reference": "715f8aa778bf012e37ffc16f619ff2125dd67d92",
+                "url": "https://api.github.com/repos/krokedil/swedbank-pay-sdk-php/zipball/330b328a3d5ef67f395a48c0f00fd953b4c870be",
+                "reference": "330b328a3d5ef67f395a48c0f00fd953b4c870be",
                 "shasum": ""
             },
             "require": {
@@ -286,9 +286,9 @@
                 "sdk"
             ],
             "support": {
-                "source": "https://github.com/krokedil/swedbank-pay-sdk-php/tree/develop-v3.1-api"
+                "source": "https://github.com/krokedil/swedbank-pay-sdk-php/tree/add-payer-country-code"
             },
-            "time": "2026-05-13T08:49:10+00:00"
+            "time": "2026-05-27T09:36:50+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -389,5 +389,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Helpers/Cart.php
+++ b/src/Helpers/Cart.php
@@ -174,7 +174,8 @@ class Cart extends PaymentDataHelper {
 				->setFirstName( WC()->customer->get_billing_first_name() )
 				->setLastName( WC()->customer->get_billing_last_name() )
 				->setEmail( WC()->customer->get_billing_email() )
-				->setMsisdn( self::format_phone_number( WC()->customer->get_billing_phone(), WC()->customer->get_billing_country() ) );
+				->setMsisdn( self::format_phone_number( WC()->customer->get_billing_phone(), WC()->customer->get_billing_country() ) )
+				->setCountryCode( WC()->customer->get_billing_country() );
 
 		$needs_shipping = false;
 		foreach ( WC()->cart->get_cart() as $cart_item ) {

--- a/src/Helpers/Order.php
+++ b/src/Helpers/Order.php
@@ -186,7 +186,8 @@ class Order extends PaymentDataHelper {
 				->setFirstName( $this->order->get_billing_first_name() )
 				->setLastName( $this->order->get_billing_last_name() )
 				->setEmail( $this->order->get_billing_email() )
-				->setMsisdn( self::format_phone_number( $this->order->get_billing_phone(), $this->order->get_billing_country() ) );
+				->setMsisdn( self::format_phone_number( $this->order->get_billing_phone(), $this->order->get_billing_country() ) )
+				->setCountryCode( $this->order->get_billing_country() );
 
 		$needs_shipping = false;
 		foreach ( $this->order->get_items() as $order_item ) {


### PR DESCRIPTION
Sets the billing_country from either the cart or the order when creating or updating a Swedbank Pay order by setting it to countryCode in the payer object for purchase orders.

**Note: We need to update the composer dependency when we have a released version of the SDK.**