### PR TITLE
change URL in backend order view

### DIFF
--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -650,9 +650,14 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			return parent::get_transaction_url( $order );
 		}
 
-		$view_transaction_url = 'https://merchantportal.swedbankpay.com/ecom/payments/details;id=%s';
+		// The meta value is a resource path (e.g. "/psp/paymentorders/{uuid}"),
+		// but the merchant portal link expects only the trailing UUID.
+		$parts        = explode( '/', $payment_order_id );
+		$payment_uuid = array_pop( $parts );
 
-		return sprintf( $view_transaction_url, rawurlencode( $payment_order_id ) );
+		$view_transaction_url = 'https://merchantportal.swedbankpay.com/psp/transactions/paymentorder/%s';
+
+		return sprintf( $view_transaction_url, rawurlencode( $payment_uuid ) );
 	}
 
 	/**

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -652,7 +652,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 		}
 
 		if ( wc_string_to_bool( $this->testmode ) ) {
-			$view_transaction_url = 'https://merchantportal.externalintegration.swedbankpay.com/ecom/paymentorders;id=%s';
+			$view_transaction_url = 'https://merchantportal.externalintegration.swedbankpay.com/ecom/payments/details;id=%s';
 		} else {
 			$view_transaction_url = 'https://merchantportal.swedbankpay.com/ecom/payments/details;id=%s';
 		}

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -253,8 +253,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
 	public function init_form_fields() {
-		$portal_url = 'yes' === $this->testmode ? 'https://merchantportal.externalintegration.swedbankpay.com' :
-			'https://merchantportal.swedbankpay.com';
+		$portal_url = 'https://merchantportal.swedbankpay.com';
 
 		// Define checkout flow options.
 		$flow_options = array(
@@ -651,11 +650,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			return parent::get_transaction_url( $order );
 		}
 
-		if ( wc_string_to_bool( $this->testmode ) ) {
-			$view_transaction_url = 'https://merchantportal.externalintegration.swedbankpay.com/ecom/payments/details;id=%s';
-		} else {
-			$view_transaction_url = 'https://merchantportal.swedbankpay.com/ecom/payments/details;id=%s';
-		}
+		$view_transaction_url = 'https://merchantportal.swedbankpay.com/ecom/payments/details;id=%s';
 
 		return sprintf( $view_transaction_url, rawurlencode( $payment_order_id ) );
 	}

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -650,10 +650,9 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			return parent::get_transaction_url( $order );
 		}
 
-		// The meta value is a resource path (e.g. "/psp/paymentorders/{uuid}"),
-		// but the merchant portal link expects only the trailing UUID.
-		$parts        = explode( '/', $payment_order_id );
-		$payment_uuid = array_pop( $parts );
+		// The meta value is a resource path (e.g. "/psp/paymentorders/{uuid}");
+		// the merchant portal link expects only the trailing UUID.
+		$payment_uuid = basename( untrailingslashit( $payment_order_id ) );
 
 		$view_transaction_url = 'https://merchantportal.swedbankpay.com/psp/transactions/paymentorder/%s';
 


### PR DESCRIPTION
Verified against orders placed with both the Redirect and **Seamless checkout flows that the payment number link opens the correct PaymentOrder in the merchant portal. Confirmed the extracted UUID
matches the `id` returned by the API in the request logs.