### PR TITLE
Add support tab to settings

### DIFF
--- a/composer-dependencies.json
+++ b/composer-dependencies.json
@@ -3,7 +3,8 @@
     "php": ">=7.4",
     "ramsey/uuid": "^3.7",
     "swedbank-pay/swedbank-pay-sdk-php": "dev-add-payer-country-code",
-    "krokedil/support": "1.0.2"
+    "krokedil/support": "1.0.2",
+    "krokedil/settings-page": "1.3.4"
   },
   "config": {
     "platform": {
@@ -18,6 +19,10 @@
     {
       "type": "vcs",
       "url": "git@github.com:krokedil/swedbank-pay-sdk-php.git"
+    },
+    {
+      "type": "vcs",
+      "url": "git@github.com:krokedil/settings-page.git"
     }
   ],
   "minimum-stability": "stable",

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -4,8 +4,53 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "744aae224012957628868616302c410d",
+    "content-hash": "0cf991e9fb2cb2e71e3818a959ca9f34",
     "packages": [
+        {
+            "name": "krokedil/settings-page",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/krokedil/settings-page.git",
+                "reference": "2ebd903fc608206cf6fdd414a74c760a282e8159"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/krokedil/settings-page/zipball/2ebd903fc608206cf6fdd414a74c760a282e8159",
+                "reference": "2ebd903fc608206cf6fdd414a74c760a282e8159",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-stubs/woocommerce-stubs": "dev-master",
+                "wp-coding-standards/wpcs": "dev-develop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Krokedil\\SettingsPage\\": "src/"
+                }
+            },
+            "scripts": {
+                "makepot": [
+                    "wp --allow-root i18n make-pot ./src ./languages/krokedil-settings.pot --domain=krokedil-settings"
+                ]
+            },
+            "license": [
+                "GPL-V2"
+            ],
+            "authors": [
+                {
+                    "name": "Krokedil AB",
+                    "email": "info@krokedil.se"
+                }
+            ],
+            "description": "A package to help setup settings pages in WordPress and WooCommerce for Krokedil plugins to add the Addons and Support tabs",
+            "support": {
+                "source": "https://github.com/krokedil/settings-page/tree/1.3.4",
+                "issues": "https://github.com/krokedil/settings-page/issues"
+            },
+            "time": "2026-04-23T19:14:17+00:00"
+        },
         {
             "name": "krokedil/support",
             "version": "1.0.2",
@@ -218,12 +263,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/swedbank-pay-sdk-php.git",
-                "reference": "330b328a3d5ef67f395a48c0f00fd953b4c870be"
+                "reference": "c2e1f0d482d19bddcad8622aa3de1e02981ea08c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/swedbank-pay-sdk-php/zipball/330b328a3d5ef67f395a48c0f00fd953b4c870be",
-                "reference": "330b328a3d5ef67f395a48c0f00fd953b4c870be",
+                "url": "https://api.github.com/repos/krokedil/swedbank-pay-sdk-php/zipball/c2e1f0d482d19bddcad8622aa3de1e02981ea08c",
+                "reference": "c2e1f0d482d19bddcad8622aa3de1e02981ea08c",
                 "shasum": ""
             },
             "require": {
@@ -288,7 +333,7 @@
             "support": {
                 "source": "https://github.com/krokedil/swedbank-pay-sdk-php/tree/add-payer-country-code"
             },
-            "time": "2026-05-27T09:36:50+00:00"
+            "time": "2026-05-29T12:53:13+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -385,9 +430,9 @@
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -11,6 +11,8 @@ use SwedbankPay\Checkout\WooCommerce\{Swedbank_Pay_Api, Swedbank_Pay_Instant_Cap
 use Krokedil\Swedbank\Pay\CheckoutFlow\{CheckoutFlow, InlineEmbedded};
 use Krokedil\Swedbank\Pay\Utility\{BlocksUtility, InstrumentsUtility, SettingsUtility, LogUtility};
 use KrokedilSwedbankPayDeps\SwedbankPay\Api\Service\Paymentorder\V3\Resource\Response\CallbackPayload;
+use KrokedilSwedbankPayDeps\Krokedil\SettingsPage\SettingsPage;
+use KrokedilSwedbankPayDeps\Krokedil\SettingsPage\Gateway;
 
 /**
  * Class Swedbank_Pay_Payment_Gateway_Checkout
@@ -555,9 +557,24 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	 * @return void
 	 */
 	public function admin_options() {
-		$this->display_errors();
+		$args = $this->get_settings_page_args();
 
-		parent::admin_options();
+		if ( empty( $args ) ) {
+			parent::admin_options();
+		} else {
+			$args['icon']             = plugin_dir_url( __FILE__ ) . '../assets/images/checkout.svg';
+			$gateway_page             = new Gateway( $this, $args );
+			$args['styled_output']    = true;
+			$args['fallback_content'] = array( $this, 'output_legacy_admin_options' );
+			$args['error_notice']     = __( 'Could not load the enhanced settings page. Showing the standard settings instead.', 'swedbank-pay-payment-menu' );
+			$args['general_content']  = array( $gateway_page, 'output' );
+			( SettingsPage::get_instance() )
+			->set_plugin_name( 'Swedbank Pay Payment Menu for WooCommerce' )
+			->register_page( $this->id, $args, $this )
+			->output( $this->id );
+		}
+
+		$this->display_errors();
 	}
 
 	/**
@@ -981,5 +998,46 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	 */
 	public function payment_fields() {
 		CheckoutFlow::payment_fields();
+	}
+
+	/**
+	 * Read the settings page arguments from remote or local storage.
+	 * If the args are stored locally, they are fetched from the transient cache.
+	 * If they are not available locally, they are fetched from the remote source and stored in the transient cache.
+	 * If the remote source is not available, the function returns null, and default settings page will be used instead.
+	 *
+	 * @return array|null
+	 */
+	private function get_settings_page_args() {
+		$args = get_transient( 'swedbank_pay_settings_page_config' );
+		if ( ! $args ) {
+			$args = wp_remote_get( 'https://krokedil-settings-page-configs.s3.eu-north-1.amazonaws.com/develop/configs/swedbank-pay-woocommerce-paymentmenu.json' );
+
+			if ( is_wp_error( $args ) ) {
+				Swedbank_Pay()->logger()->log(
+					WC_Log_Levels::ERROR,
+					__METHOD__,
+					array(
+						'message' => 'Unable to fetch settings page configuration from remote source.',
+						'error'   => $args->get_error_message(),
+					)
+				);
+				return null;
+			}
+
+			$args = wp_remote_retrieve_body( $args );
+			set_transient( 'swedbank_pay_settings_page_config', $args, 60 * 60 * 24 ); // 24 hours lifetime.
+		}
+
+		return json_decode( $args, true );
+	}
+
+	/**
+	 * Output the standard WooCommerce admin options.
+	 *
+	 * @return void
+	 */
+	public function output_legacy_admin_options() {
+		parent::admin_options();
 	}
 }

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -1011,7 +1011,7 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 	private function get_settings_page_args() {
 		$args = get_transient( 'swedbank_pay_settings_page_config' );
 		if ( ! $args ) {
-			$args = wp_remote_get( 'https://krokedil-settings-page-configs.s3.eu-north-1.amazonaws.com/develop/configs/swedbank-pay-woocommerce-paymentmenu.json' );
+			$args = wp_remote_get( 'https://krokedil-settings-page-configs.s3.eu-north-1.amazonaws.com/main/configs/swedbank-pay-woocommerce-paymentmenu.json' );
 
 			if ( is_wp_error( $args ) ) {
 				Swedbank_Pay()->logger()->log(


### PR DESCRIPTION
Adds the support tab to the plugin settings, by implementing our settings-page package.