### PR TITLE
Update payment reference for inline embedded purchases to the WooCommerce order number

### DIFF
--- a/composer-dependencies.json
+++ b/composer-dependencies.json
@@ -2,7 +2,7 @@
   "require": {
     "php": ">=7.4",
     "ramsey/uuid": "^3.7",
-    "swedbank-pay/swedbank-pay-sdk-php": "dev-add-payer-country-code",
+    "swedbank-pay/swedbank-pay-sdk-php": "6.3.0",
     "krokedil/support": "1.0.2"
   },
   "config": {
@@ -14,10 +14,6 @@
     {
       "type": "vcs",
       "url": "git@github.com:krokedil/support.git"
-    },
-    {
-      "type": "vcs",
-      "url": "git@github.com:krokedil/swedbank-pay-sdk-php.git"
     }
   ],
   "minimum-stability": "stable",

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "744aae224012957628868616302c410d",
+    "content-hash": "3e69ff01f9c46965a361a8cd1aea81c3",
     "packages": [
         {
             "name": "krokedil/support",
@@ -214,16 +214,16 @@
         },
         {
             "name": "swedbank-pay/swedbank-pay-sdk-php",
-            "version": "dev-add-payer-country-code",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/krokedil/swedbank-pay-sdk-php.git",
-                "reference": "330b328a3d5ef67f395a48c0f00fd953b4c870be"
+                "url": "https://github.com/SwedbankPay/swedbank-pay-sdk-php.git",
+                "reference": "1a85aa5d724954f6b8852a982f8f7cb02c68ebca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/swedbank-pay-sdk-php/zipball/330b328a3d5ef67f395a48c0f00fd953b4c870be",
-                "reference": "330b328a3d5ef67f395a48c0f00fd953b4c870be",
+                "url": "https://api.github.com/repos/SwedbankPay/swedbank-pay-sdk-php/zipball/1a85aa5d724954f6b8852a982f8f7cb02c68ebca",
+                "reference": "1a85aa5d724954f6b8852a982f8f7cb02c68ebca",
                 "shasum": ""
             },
             "require": {
@@ -246,12 +246,7 @@
                     "SwedbankPay\\": "src/SwedbankPay/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "SwedbankPayTest\\": "tests/Unit/SwedbankPayTest/",
-                    "SwedbankPayTest\\Test\\": "tests/Functional/SwedbankPayTest/Test/"
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -286,9 +281,10 @@
                 "sdk"
             ],
             "support": {
-                "source": "https://github.com/krokedil/swedbank-pay-sdk-php/tree/add-payer-country-code"
+                "issues": "https://github.com/SwedbankPay/swedbank-pay-sdk-php/issues",
+                "source": "https://github.com/SwedbankPay/swedbank-pay-sdk-php/tree/v6.3.0"
             },
-            "time": "2026-05-27T09:36:50+00:00"
+            "time": "2026-06-03T09:12:40+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -377,9 +373,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "swedbank-pay/swedbank-pay-sdk-php": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e69ff01f9c46965a361a8cd1aea81c3",
+    "content-hash": "fe3c272d76017ec66d9600bf104ddfe6",
     "packages": [
         {
             "name": "krokedil/settings-page",

--- a/composer.lock
+++ b/composer.lock
@@ -455,16 +455,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.1",
+            "version": "v6.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
                 "shasum": ""
             },
             "conflict": {
@@ -474,7 +474,7 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
-                "php-stubs/generator": "^0.8.3",
+                "php-stubs/generator": "^0.8.6",
                 "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
@@ -501,9 +501,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
             },
-            "time": "2026-02-03T19:29:21+00:00"
+            "time": "2026-05-01T20:36:01+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -2492,5 +2492,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -372,14 +372,15 @@ class Swedbank_Pay_Api {
 	 * Update a embedded payment.
 	 *
 	 * @param string|null $instrument The instrument to use for the payment, e.g. 'CreditCard'. This is optional and may not be needed for all flows or gateways.
+	 * @param WC_Order|null $order The order object to get the order number from if it exists.
 	 *
 	 * @return WP_Error|ResponseServiceInterface
 	 */
-	public function update_embedded_purchase( $instrument = null ) {
+	public function update_embedded_purchase( $instrument = null, $order = null ) {
 		$update_payment_url = WC()->session->get( 'swedbank_pay_update_order_url' );
 		$helper             = new Cart();
 
-		$payment_order = $helper->get_update_payment_order();
+		$payment_order = $helper->get_update_payment_order( $order );
 
 		// Set the instrument if provided.
 		if ( ! empty( $instrument ) ) {

--- a/includes/class-swedbank-pay-scheduler.php
+++ b/includes/class-swedbank-pay-scheduler.php
@@ -46,11 +46,9 @@ class Swedbank_Pay_Scheduler {
 		add_action( self::ACTION_ID, array( $this, 'run' ), 10, 2 );
 	}
 
-
 	/**
 	 * Code to execute for each item in the queue.
 	 *
-	 * @throws \Exception If the webhook data is invalid or if the order cannot be found.
 	 * @throws \WP_Exception If there is an error with the payment gateway or if the payment cannot be finalized.
 	 *
 	 * @param string $payment_method_id The payment method ID.
@@ -63,7 +61,6 @@ class Swedbank_Pay_Scheduler {
 			'payment_method_id' => $payment_method_id,
 			'webhook_data'      => $webhook_data,
 		);
-
 		Swedbank_Pay()->logger()->info( sprintf( '[SCHEDULER]: Start task: %s', wp_json_encode( array( $payment_method_id, $webhook_data ) ) ), $context );
 
 		try {
@@ -85,23 +82,13 @@ class Swedbank_Pay_Scheduler {
 			$context['payment_number']   = $payment_number;
 			$context['order_reference']  = $order_reference;
 
-			if ( ! empty( $order_reference ) ) {
-				// Use the order reference for quicker lookup.
-				$order = wc_get_order( $order_reference );
-				if ( ! $order || $order->get_meta( '_payex_paymentorder_id' ) !== $payment_order_id ) {
+			// Get the WooCommerce order using the order reference or the payment order id.
+			$order = $this->get_woocommerce_order( $order_reference, $payment_order_id );
 
-					// Fallback to payment order ID if the order reference does not match.
-					$order = swedbank_pay_get_order( $payment_order_id );
-					if ( ! $order ) {
-						Swedbank_Pay()->logger()->error( "[SCHEDULER]: Failed to find order with order reference: {$order_reference} and payment order ID: $payment_order_id", $context );
-						throw new \Exception( "[SCHEDULER]: Failed to find order with payment order ID: $payment_order_id" );
-					}
-				}
-			} else {
-				$order = swedbank_pay_get_order( $payment_order_id );
-				if ( ! $order ) {
-					throw new \Exception( "[SCHEDULER]: Failed to find order with payment order ID: $payment_order_id" );
-				}
+			// If the order is a refund order, skip and just return true.
+			if ( $order instanceof \WC_Order_Refund ) {
+				Swedbank_Pay()->logger()->info( "[SCHEDULER]: Callback for payment order id #{$payment_order_id} is a WooCommerce refund order. Skipping.", $context );
+				return true;
 			}
 
 			$gateway = swedbank_pay_get_payment_method( $order );
@@ -139,5 +126,34 @@ class Swedbank_Pay_Scheduler {
 
 		Swedbank_Pay()->logger()->info( "[SCHEDULER]: Successfully processed payment for order #{$order->get_order_number()} with payment number #{$context['payment_number']}.", $context );
 		return false;
+	}
+
+	/**
+	 * Try to get the WooCommerce order using the order reference or the payment order id.
+	 *
+	 * @param string $order_reference The order reference to find the order by.
+	 * @param string $payment_order_id The payment order ID to find the order by if the order was not found by the order reference.
+	 *
+	 * @throws \WP_Exception
+	 *
+	 * @return \WC_Order|\WC_Order_Refund
+	 */
+	private function get_woocommerce_order( $order_reference, $payment_order_id ) {
+		$order = null;
+
+		// If we have an order reference, try to find the order by the order reference.
+		$order = wc_get_order( $order_reference );
+
+		// If we don't have an order, or the order we have does not match the payment order ID, try to find the order by payment order ID.
+		if ( ! $order || $order->get_meta( '_payex_paymentorder_id' ) !== $payment_order_id ) {
+			$order = swedbank_pay_get_order( $payment_order_id );
+		}
+
+		// If the order is still not found, throw an error and exit.
+		if ( ! $order ) {
+			throw new \WP_Exception( "[SCHEDULER]: Failed to find order with payment order ID: $payment_order_id" );
+		}
+
+		return $order;
 	}
 }

--- a/includes/class-swedbank-pay-scheduler.php
+++ b/includes/class-swedbank-pay-scheduler.php
@@ -85,10 +85,10 @@ class Swedbank_Pay_Scheduler {
 			// Get the WooCommerce order using the order reference or the payment order id.
 			$order = $this->get_woocommerce_order( $order_reference, $payment_order_id );
 
-			// If the order is a refund order, skip and just return true.
+			// If the order is a refund order, skip processing.
 			if ( $order instanceof \WC_Order_Refund ) {
 				Swedbank_Pay()->logger()->info( "[SCHEDULER]: Callback for payment order id #{$payment_order_id} is a WooCommerce refund order. Skipping.", $context );
-				return true;
+				return false;
 			}
 
 			$gateway = swedbank_pay_get_payment_method( $order );

--- a/src/CheckoutFlow/CheckoutFlow.php
+++ b/src/CheckoutFlow/CheckoutFlow.php
@@ -27,6 +27,13 @@ abstract class CheckoutFlow {
 	protected $api;
 
 	/**
+	 * The WooCommerce order if one exists.
+	 *
+	 * @var \WC_Order|null
+	 */
+	protected $order;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param \WC_Order|null $order The WooCommerce order to be processed. Can be null if during checkout.
@@ -36,6 +43,7 @@ abstract class CheckoutFlow {
 	public function __construct( $order = null ) {
 		$this->gateway = empty( $order ) ? SettingsUtility::get_gateway_class() : swedbank_pay_get_payment_method( $order );
 		$this->api     = $this->get_api();
+		$this->order   = $order;
 
 		$this->init();
 	}

--- a/src/CheckoutFlow/InlineEmbedded.php
+++ b/src/CheckoutFlow/InlineEmbedded.php
@@ -180,7 +180,7 @@ class InlineEmbedded extends CheckoutFlow {
 				}
 
 				// Update the existing payment.
-				$result = $this->api->update_embedded_purchase();
+				$result = $this->api->update_embedded_purchase( null, $this->order );
 				// Check for errors.
 				if ( is_wp_error( $result ) ) {
 					throw new \Exception( $result->get_error_message() );

--- a/src/Helpers/Cart.php
+++ b/src/Helpers/Cart.php
@@ -78,7 +78,7 @@ class Cart extends PaymentDataHelper {
 		foreach ( $formatted_items as $item ) {
 			// Swedbank does not allow negative values in any numeric field which will always be the case for WC_Order_Refund unless the row is a discount.
 			$items[] = array_map(
-				fn( $value ) => is_numeric( $value ) ? ( $item[ Swedbank_Pay_Order_Item::FIELD_TYPE ] === Swedbank_Pay_Order_Item::TYPE_DISCOUNT ? $value : abs( $value ) ) : $value,
+				fn( $value ) => is_numeric( $value ) ? ( Swedbank_Pay_Order_Item::TYPE_DISCOUNT === $item[ Swedbank_Pay_Order_Item::FIELD_TYPE ] ? $value : abs( $value ) ) : $value,
 				$item
 			);
 
@@ -313,7 +313,7 @@ class Cart extends PaymentDataHelper {
 
 		// If the order is provided, Set the order reference in the payee info to ensure it is updated in Swedbank Pay's system.
 		if ( ! empty( $order ) ) {
-			$payee_info = $payment_order->getPayeeInfo() ?: new PaymentorderPayeeInfo();
+			$payee_info = $payment_order->getPayeeInfo() ?: new PaymentorderPayeeInfo(); // phpcs:ignore Universal.Operators.DisallowShortTernary.Found -- Safe to use short ternary here.
 			$payee_info->setOrderReference( $order->get_order_number() );
 			$payment_order->setPayeeInfo( apply_filters( 'swedbank_pay_payee', $payee_info, $this ) );
 		}

--- a/src/Helpers/Cart.php
+++ b/src/Helpers/Cart.php
@@ -279,9 +279,12 @@ class Cart extends PaymentDataHelper {
 	 * This method constructs a Paymentorder object for updating an existing payment order.
 	 *
 	 * @hook swedbank_pay_update_payment_order
+	 *
+	 * @param \WC_Order|null $order The order object to get the order number from if it exists.
+	 *
 	 * @return Paymentorder
 	 */
-	public function get_update_payment_order() {
+	public function get_update_payment_order( $order = null ) {
 		$items                 = $this->get_formatted_items();
 		$this->formatted_items = $items;
 		$payment_order         = ( new Paymentorder() )
@@ -307,6 +310,13 @@ class Cart extends PaymentDataHelper {
 			->setOrderItems( $this->get_order_items() );
 
 		self::set_client_information( $payment_order ); // Set the client information.
+
+		// If the order is provided, Set the order reference in the payee info to ensure it is updated in Swedbank Pay's system.
+		if ( ! empty( $order ) ) {
+			$payee_info = $payment_order->getPayeeInfo() ?: new PaymentorderPayeeInfo();
+			$payee_info->setOrderReference( $order->get_order_number() );
+			$payment_order->setPayeeInfo( apply_filters( 'swedbank_pay_payee', $payee_info, $this ) );
+		}
 
 		return apply_filters( 'swedbank_pay_update_payment_order', $payment_order, $this );
 	}


### PR DESCRIPTION
Adds logic to update the payments order reference when the order is placed in WooCommerce.

Also fixed some errors in the scheduled callback handler that would fail to get the correct order in some cases, and would attempt to process a transaction for existing WooCommerce refunds, which threw errors silently. Now we intentionally skip refund orders during the handler to prevent errors.