### PR TITLE
Fix cancel payment in metabox

### DIFF
--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -1170,12 +1170,23 @@ class Swedbank_Pay_Api {
 				$context
 			);
 
-			$transaction = $this->financial_transaction_to_array(
-				$response_service->getResponseResource()->getLatestFinancialTransaction()
-			);
+			$financial_transaction = $response_service->getResponseResource()->getLatestFinancialTransaction();
 
-			if ( is_wp_error( $transaction ) ) {
-				$context['error'] = $transaction->get_error_message();
+			// A cancellation only applies to an authorized (uncaptured) amount and its financial transaction is optional, so the financial transactions list may be empty.
+			if ( ! empty( $financial_transaction ) ) {
+				$transaction = $this->financial_transaction_to_array( $financial_transaction );
+
+				$this->process_transaction( $order, $transaction );
+
+				return $transaction;
+			}
+
+			// No financial transaction was returned, so confirm the cancellation through the payment order status instead.
+			$payment_order = $response_service->getResponseResource()->getPaymentOrder();
+			$status        = $payment_order ? $payment_order->getStatus() : null;
+
+			if ( 'Cancelled' !== $status ) {
+				$context['error'] = sprintf( 'Cancellation not confirmed. Payment order status: %s.', $status );
 				LogUtility::log_request(
 					'[ORDER MANAGEMENT]: cancel checkout',
 					$request_service->getClient(),
@@ -1183,12 +1194,26 @@ class Swedbank_Pay_Api {
 					$context
 				);
 
-				return $transaction;
+				return new WP_Error(
+					'cancel',
+					__( 'The payment could not be cancelled. Please verify the payment status in Swedbank Pay.', 'swedbank-pay-payment-menu' )
+				);
 			}
 
-			$this->process_transaction( $order, $transaction );
+			$transaction_id = $payment_order->getNumber();
 
-			return $transaction;
+			$this->update_order_status(
+				$order,
+				'cancelled',
+				$transaction_id,
+				// translators: 1: transaction ID.
+				sprintf( __( 'Payment has been cancelled. Transaction: %s', 'swedbank-pay-payment-menu' ), $transaction_id )
+			);
+
+			return array(
+				'number' => $transaction_id,
+				'type'   => self::TYPE_CANCELLATION,
+			);
 		} catch ( ClientException $e ) {
 			$context['error'] = sprintf( '%s: API Exception: %s', __METHOD__, $e->getMessage() );
 			LogUtility::log_request(

--- a/includes/class-swedbank-pay-payment-actions.php
+++ b/includes/class-swedbank-pay-payment-actions.php
@@ -181,10 +181,10 @@ class Swedbank_Pay_Payment_Actions {
 	/**
 	 * Perform Refund.
 	 *
-	 * @param \WC_Order $order
-	 * @param array     $lines
-	 * @param array     $items
-	 * @param $reason
+	 * @param WC_Order $order
+	 * @param array    $lines
+	 * @param string   $reason
+	 * @param bool     $create_credit_memo
 	 *
 	 * @return \WP_Error|true
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -219,7 +219,7 @@ class Swedbank_Pay_Payment_Actions {
 			/** @var WC_Order_Item $item */
 			$item = $order->get_item( $item_id );
 			if ( ! $item ) {
-				return new \WP_Error( 'error', 'Unable to retrieve order item: ' . $item_id );
+				return new \WP_Error( 'error', "Unable to retrieve order item: $item_id" );
 			}
 
 			$product_name = trim( $item->get_name() );
@@ -255,7 +255,7 @@ class Swedbank_Pay_Payment_Actions {
 			}
 
 			Swedbank_Pay()->logger()->info(
-				sprintf(
+				\sprintf(
 					'[REFUND]: Refund item %s. qty: %s, total: %s. tax: %s. amount: %s',
 					$item_id,
 					$qty,
@@ -407,7 +407,7 @@ class Swedbank_Pay_Payment_Actions {
 		$transaction_id = $result['number'];
 
 		$order->add_order_note(
-			sprintf(
+			\sprintf(
 			/* translators: 1: transaction 2: state 3: reason */                __(
 				'Refund process has been executed from order admin. Transaction ID: %1$s. State: %2$s. Reason: %3$s', //phpcs:ignore
 				'swedbank-pay-payment-menu' //phpcs:ignore
@@ -424,7 +424,7 @@ class Swedbank_Pay_Payment_Actions {
 		if ( $create_credit_memo ) {
 			$amount = 0;
 			foreach ( $items as $item ) {
-				$amount += ( $item[ Swedbank_Pay_Order_Item::FIELD_AMOUNT ] / 100 );
+				$amount += $item[ Swedbank_Pay_Order_Item::FIELD_AMOUNT ] / 100;
 			}
 
 			$refund = wc_create_refund(
@@ -440,7 +440,7 @@ class Swedbank_Pay_Payment_Actions {
 			if ( is_wp_error( $refund ) ) {
 				$context['error'] = join( '; ', $refund->get_error_messages() );
 				Swedbank_Pay()->logger()->error(
-					sprintf(
+					\sprintf(
 						'[REFUND]: Refund could not be created. Error: %s',
 						join( '; ', $refund->get_error_messages() )
 					),
@@ -448,7 +448,7 @@ class Swedbank_Pay_Payment_Actions {
 				);
 
 				$order->add_order_note(
-					sprintf(
+					\sprintf(
 						'Refund could not be created. Error: %s',
 						join( '; ', $refund->get_error_messages() )
 					)

--- a/includes/class-swedbank-pay-payment-actions.php
+++ b/includes/class-swedbank-pay-payment-actions.php
@@ -144,9 +144,7 @@ class Swedbank_Pay_Payment_Actions {
 		$result = $this->gateway->api->cancel_checkout( $order );
 
 		if ( is_wp_error( Swedbank_Pay()->system_report()->request( $result ) ) ) {
-			$order->add_order_note(
-				'Cancellation has been failed. Error: ' . $result->get_error_message()
-			);
+			$order->add_order_note( "Cancellation failed. Error: {$result->get_error_message()}" );
 		}
 
 		return $result;

--- a/includes/class-swedbank-pay-payment-actions.php
+++ b/includes/class-swedbank-pay-payment-actions.php
@@ -12,7 +12,6 @@ use WC_Order_Item_Fee;
 use WC_Order_Item_Shipping;
 use WC_Product;
 use WC_Payment_Gateway;
-use WC_Log_Levels;
 use WC_Order;
 use Swedbank_Pay_Payment_Gateway_Checkout;
 

--- a/includes/class-swedbank-pay-payment-actions.php
+++ b/includes/class-swedbank-pay-payment-actions.php
@@ -135,7 +135,6 @@ class Swedbank_Pay_Payment_Actions {
 	 * @return \WP_Error|array
 	 */
 	public function cancel_payment( $order ) {
-		// @todo Add more cancellation logic
 		remove_action(
 			'woocommerce_order_status_changed',
 			Swedbank_Pay_Admin::class . '::order_status_changed_transaction',
@@ -143,7 +142,15 @@ class Swedbank_Pay_Payment_Actions {
 		);
 
 		/** @var \WP_Error|array $result */
-		return $this->gateway->api->cancel_checkout( $order );
+		$result = $this->gateway->api->cancel_checkout( $order );
+
+		if ( is_wp_error( Swedbank_Pay()->system_report()->request( $result ) ) ) {
+			$order->add_order_note(
+				'Cancellation has been failed. Error: ' . $result->get_error_message()
+			);
+		}
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
* Fix           - Fixed the "Cancel Payment" button in the order admin, which showed an error and left the order uncancelled even though the payment had already been cancelled with Swedbank Pay. Cancellations now complete correctly, mark the order as cancelled, and record the outcome as an order note.

https://app.clickup.com/t/2423261/869de9vdr