### PR TITLE
Add support for asynchronous reversals

### DIFF
--- a/.changelogs/feature-asynchronous-reversals.md
+++ b/.changelogs/feature-asynchronous-reversals.md
@@ -1,0 +1,4 @@
+Type: Feature
+Needs Documentation: yes
+
+Added support for asynchronous reversals. Payment methods that process refunds asynchronously (such as Banklink in the Baltics) answer the reversal request with HTTP 202 Accepted and report the outcome in a later callback. The refund is now registered in WooCommerce immediately and marked as awaiting confirmation. When the callback arrives, a confirmed reversal is processed as usual, while a rejected reversal puts the order on hold so the merchant can review it. No other payment action can be performed on the order while a reversal is awaiting confirmation. Should the callback never arrive, the refund is rechecked on a schedule for up to three days, after which the order is put on hold for manual verification.

--- a/.changelogs/feature-asynchronous-reversals.md
+++ b/.changelogs/feature-asynchronous-reversals.md
@@ -1,4 +1,4 @@
 Type: Feature
 Needs Documentation: yes
 
-Added support for asynchronous reversals. Payment methods that process refunds asynchronously (such as Banklink in the Baltics) answer the reversal request with HTTP 202 Accepted and report the outcome in a later callback. The refund is now registered in WooCommerce immediately and marked as awaiting confirmation. When the callback arrives, a confirmed reversal is processed as usual, while a rejected reversal puts the order on hold so the merchant can review it. No other payment action can be performed on the order while a reversal is awaiting confirmation. Should the callback never arrive, the refund is rechecked on a schedule for up to three days, after which the order is put on hold for manual verification.
+Added support for refunds that Swedbank Pay confirms after a delay, such as Banklink refunds in the Baltics. The order is put on hold if the refund is turned down or never confirmed.

--- a/.changelogs/fix-refund-by-amount-vat.md
+++ b/.changelogs/fix-refund-by-amount-vat.md
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue where refunding an order by entering an amount, rather than selecting line items, was rejected by Swedbank Pay on any order that included VAT.

--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -1499,18 +1499,7 @@ class Swedbank_Pay_Api {
 	 * @return array|null The pending transaction array, or null when the reversal completed.
 	 */
 	private function maybe_init_async_reversal( $request_service, $order, $transaction_data ) {
-		/**
-		 * Force the asynchronous reversal path regardless of the response code.
-		 *
-		 * Test seam. Forcing it on a reversal that actually completed leaves the order blocked
-		 * from further payment actions until the recheck ladder gives up.
-		 *
-		 * @param bool     $force Whether to treat the reversal as accepted asynchronously.
-		 * @param WC_Order $order The order being refunded.
-		 */
-		$force = apply_filters( 'swedbank_pay_force_async_reversal', false, $order );
-
-		if ( 202 !== (int) $request_service->getClient()->getResponseCode() && ! $force ) {
+		if ( 202 !== (int) $request_service->getClient()->getResponseCode() ) {
 			return null;
 		}
 

--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -1454,7 +1454,9 @@ class Swedbank_Pay_Api {
 	 *
 	 * @param WC_Order $order The order to check.
 	 *
-	 * @return WP_Error|false WP_Error when a reversal is still pending, false otherwise.
+	 * @return WP_Error|false `pending_reversal` when a reversal is still awaiting confirmation,
+	 *                        `pending_reversal_check_failed` when its status could not be
+	 *                        verified, false when nothing is pending.
 	 */
 	public function maybe_block_pending_reversal( WC_Order $order ) {
 		$async_reversal = Swedbank_Pay()->async_reversal();
@@ -1463,10 +1465,24 @@ class Swedbank_Pay_Api {
 		}
 
 		// Try to resolve the pending reversal(s) before blocking.
-		$async_reversal->check_pending_reversals( $order );
+		$recheck = $async_reversal->check_pending_reversals( $order );
 
 		if ( ! $async_reversal->has_pending( $order ) ) {
 			return false;
+		}
+
+		// Still pending, but distinguish the two reasons: waiting on Swedbank Pay is not the
+		// same as being unable to ask them. Both block the operation, since the outcome is
+		// unknown either way, but the merchant should be told which it is.
+		if ( is_wp_error( $recheck ) ) {
+			return new WP_Error(
+				'pending_reversal_check_failed',
+				sprintf(
+					// translators: %s: the error reported while checking the reversal.
+					__( 'A refund on this order is awaiting confirmation from Swedbank Pay, and its status could not be verified: %s. Please try again in a moment.', 'swedbank-pay-payment-menu' ),
+					$recheck->get_error_message()
+				)
+			);
 		}
 
 		return new WP_Error(

--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -1269,10 +1269,12 @@ class Swedbank_Pay_Api {
 			'amount'           => $amount,
 		);
 
+		// Keep the VAT that get_transaction_data() derived from the order items. Swedbank Pay
+		// rejects a transaction whose vatAmount does not match the summed vatAmount of the order
+		// items it carries, so zeroing it here failed on any order with VAT.
 		$helper           = new Order( $order );
 		$transaction_data = $helper->get_transaction_data()
 			->setAmount( round( $amount * 100 ) )
-			->setVatAmount( 0 )
 			->setDescription( sprintf( 'Refund Order #%s.', $order->get_order_number() ) );
 
 		$transaction = new TransactionObject();

--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -1298,12 +1298,9 @@ class Swedbank_Pay_Api {
 				$context
 			);
 
-			// HTTP 202: the reversal is processed asynchronously and is not included in
-			// the response. The result arrives later via the payee callback.
-			if ( 202 === (int) $request_service->getClient()->getResponseCode()
-				|| apply_filters( 'swedbank_pay_force_async_reversal', false, $order )
-			) {
-				return Swedbank_Pay()->async_reversal()->init_pending( $order, $transaction_data, 'amount' );
+			$pending = $this->maybe_init_async_reversal( $request_service, $order, $transaction_data );
+			if ( null !== $pending ) {
+				return $pending;
 			}
 
 			$transaction = $this->financial_transaction_to_array(
@@ -1401,12 +1398,9 @@ class Swedbank_Pay_Api {
 				$context
 			);
 
-			// HTTP 202: the reversal is processed asynchronously and is not included in
-			// the response. The result arrives later via the payee callback.
-			if ( 202 === (int) $request_service->getClient()->getResponseCode()
-				|| apply_filters( 'swedbank_pay_force_async_reversal', false, $order )
-			) {
-				return Swedbank_Pay()->async_reversal()->init_pending( $order, $transaction_data, 'items', $refund_order );
+			$pending = $this->maybe_init_async_reversal( $request_service, $order, $transaction_data );
+			if ( null !== $pending ) {
+				return $pending;
 			}
 
 			$transaction = $this->financial_transaction_to_array(
@@ -1489,6 +1483,36 @@ class Swedbank_Pay_Api {
 			'pending_reversal',
 			__( 'A refund on this order is still awaiting confirmation from Swedbank Pay. Please wait until it has been confirmed before performing another action on the payment.', 'swedbank-pay-payment-menu' )
 		);
+	}
+
+	/**
+	 * Register the reversal as pending when Swedbank Pay accepted it without completing it.
+	 *
+	 * HTTP 202 means the reversal is not in the response; the outcome arrives via the callback.
+	 *
+	 * @param mixed    $request_service The reversal request that was sent.
+	 * @param WC_Order $order The order being refunded.
+	 * @param mixed    $transaction_data The transaction data sent in the request.
+	 *
+	 * @return array|null The pending transaction array, or null when the reversal completed.
+	 */
+	private function maybe_init_async_reversal( $request_service, $order, $transaction_data ) {
+		/**
+		 * Force the asynchronous reversal path regardless of the response code.
+		 *
+		 * Test seam. Forcing it on a reversal that actually completed leaves the order blocked
+		 * from further payment actions until the recheck ladder gives up.
+		 *
+		 * @param bool     $force Whether to treat the reversal as accepted asynchronously.
+		 * @param WC_Order $order The order being refunded.
+		 */
+		$force = apply_filters( 'swedbank_pay_force_async_reversal', false, $order );
+
+		if ( 202 !== (int) $request_service->getClient()->getResponseCode() && ! $force ) {
+			return null;
+		}
+
+		return Swedbank_Pay()->async_reversal()->init_pending( $order, $transaction_data );
 	}
 
 	/**

--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -1050,6 +1050,11 @@ class Swedbank_Pay_Api {
 			return new \WP_Error( 'missing_payment_id', 'Unable to get the payment order ID' );
 		}
 
+		$pending_reversal_error = $this->maybe_block_pending_reversal( $order );
+		if ( is_wp_error( $pending_reversal_error ) ) {
+			return $pending_reversal_error;
+		}
+
 		$context = array(
 			'order_id'         => $order->get_id(),
 			'order_number'     => $order->get_order_number(),
@@ -1127,6 +1132,11 @@ class Swedbank_Pay_Api {
 		$payment_order_id = $order->get_meta( '_payex_paymentorder_id' );
 		if ( empty( $payment_order_id ) ) {
 			return new \WP_Error( 'missing_payment_id', 'Unable to get the payment order ID' );
+		}
+
+		$pending_reversal_error = $this->maybe_block_pending_reversal( $order );
+		if ( is_wp_error( $pending_reversal_error ) ) {
+			return $pending_reversal_error;
 		}
 
 		$context = array(
@@ -1246,6 +1256,11 @@ class Swedbank_Pay_Api {
 			return new WP_Error( 0, 'Unable to get the payment order ID' );
 		}
 
+		$pending_reversal_error = $this->maybe_block_pending_reversal( $order );
+		if ( is_wp_error( $pending_reversal_error ) ) {
+			return $pending_reversal_error;
+		}
+
 		$context = array(
 			'order_id'         => $order->get_id(),
 			'order_number'     => $order->get_order_number(),
@@ -1282,6 +1297,14 @@ class Swedbank_Pay_Api {
 				WC_Log_Levels::DEBUG,
 				$context
 			);
+
+			// HTTP 202: the reversal is processed asynchronously and is not included in
+			// the response. The result arrives later via the payee callback.
+			if ( 202 === (int) $request_service->getClient()->getResponseCode()
+				|| apply_filters( 'swedbank_pay_force_async_reversal', false, $order )
+			) {
+				return Swedbank_Pay()->async_reversal()->init_pending( $order, $transaction_data, 'amount' );
+			}
 
 			$transaction = $this->financial_transaction_to_array(
 				$response_service->getResponseResource()->getLatestFinancialTransaction()
@@ -1336,6 +1359,12 @@ class Swedbank_Pay_Api {
 		if ( empty( $payment_order_id ) ) {
 			return new WP_Error( 0, 'Unable to get the payment order ID' );
 		}
+
+		$pending_reversal_error = $this->maybe_block_pending_reversal( $order );
+		if ( is_wp_error( $pending_reversal_error ) ) {
+			return $pending_reversal_error;
+		}
+
 		$helper           = new Order( $refund_order );
 		$transaction_data = $helper->get_transaction_data();
 		$amount           = $transaction_data->getAmount();
@@ -1371,6 +1400,14 @@ class Swedbank_Pay_Api {
 				WC_Log_Levels::DEBUG,
 				$context
 			);
+
+			// HTTP 202: the reversal is processed asynchronously and is not included in
+			// the response. The result arrives later via the payee callback.
+			if ( 202 === (int) $request_service->getClient()->getResponseCode()
+				|| apply_filters( 'swedbank_pay_force_async_reversal', false, $order )
+			) {
+				return Swedbank_Pay()->async_reversal()->init_pending( $order, $transaction_data, 'items', $refund_order );
+			}
 
 			$transaction = $this->financial_transaction_to_array(
 				$response_service->getResponseResource()->getLatestFinancialTransaction()
@@ -1408,6 +1445,37 @@ class Swedbank_Pay_Api {
 	}
 
 	/**
+	 * Block post purchase operations while a reversal is awaiting confirmation.
+	 *
+	 * Swedbank Pay accepts no further capture, cancel or reversal on a payment order that
+	 * has a reversal in progress, so the request is stopped here rather than being rejected
+	 * by the API. Re-checks the payment order first, so an order whose callback never
+	 * arrived heals itself the next time an operation is attempted.
+	 *
+	 * @param WC_Order $order The order to check.
+	 *
+	 * @return WP_Error|false WP_Error when a reversal is still pending, false otherwise.
+	 */
+	public function maybe_block_pending_reversal( WC_Order $order ) {
+		$async_reversal = Swedbank_Pay()->async_reversal();
+		if ( ! $async_reversal->has_pending( $order ) ) {
+			return false;
+		}
+
+		// Try to resolve the pending reversal(s) before blocking.
+		$async_reversal->check_pending_reversals( $order );
+
+		if ( ! $async_reversal->has_pending( $order ) ) {
+			return false;
+		}
+
+		return new WP_Error(
+			'pending_reversal',
+			__( 'A refund on this order is still awaiting confirmation from Swedbank Pay. Please wait until it has been confirmed before performing another action on the payment.', 'swedbank-pay-payment-menu' )
+		);
+	}
+
+	/**
 	 * Bridge a typed v3.1 FinancialTransaction to the array shape that
 	 * {@see process_transaction()} expects.
 	 *
@@ -1425,6 +1493,8 @@ class Swedbank_Pay_Api {
 		return array(
 			'number'         => $ft->getNumber(),
 			'type'           => $ft->getType(),
+			// Financial transactions only appear in the list once they are completed.
+			'state'          => 'Completed',
 			'amount'         => $ft->getAmount(),
 			'created'        => $ft->getCreated(),
 			'updated'        => $ft->getUpdated(),

--- a/includes/class-swedbank-pay-payment-actions.php
+++ b/includes/class-swedbank-pay-payment-actions.php
@@ -421,11 +421,6 @@ class Swedbank_Pay_Payment_Actions {
 
 		$this->save_refunded_items( $order, $lines );
 
-		// Keep the refunded lines on the pending entry, so they can be rolled back if the reversal fails.
-		if ( $is_pending ) {
-			Swedbank_Pay()->async_reversal()->set_pending_field( $order, $result['payeeReference'], 'lines', $lines );
-		}
-
 		// Create Credit Memo.
 		if ( $create_credit_memo ) {
 			$amount = 0;
@@ -443,10 +438,6 @@ class Swedbank_Pay_Payment_Actions {
 					'restock_items'  => true,
 				)
 			);
-
-			if ( ! is_wp_error( $refund ) && $is_pending ) {
-				Swedbank_Pay()->async_reversal()->set_pending_field( $order, $result['payeeReference'], 'refund_id', $refund->get_id() );
-			}
 
 			if ( is_wp_error( $refund ) ) {
 				$context['error'] = join( '; ', $refund->get_error_messages() );

--- a/includes/class-swedbank-pay-payment-actions.php
+++ b/includes/class-swedbank-pay-payment-actions.php
@@ -401,21 +401,30 @@ class Swedbank_Pay_Payment_Actions {
 			return $result;
 		}
 
-		$transaction_id = $result['number'];
+		$is_pending = ! empty( $result['pending'] );
 
-		$order->add_order_note(
-			\sprintf(
-			/* translators: 1: transaction 2: state 3: reason */                __(
-				'Refund process has been executed from order admin. Transaction ID: %1$s. State: %2$s. Reason: %3$s', //phpcs:ignore
-				'swedbank-pay-payment-menu' //phpcs:ignore
-			), //phpcs:ignore
-				$transaction_id,
-				$result['state'],
-				empty( $reason ) ? '-' : $reason
-			)
-		);
+		if ( ! $is_pending ) {
+			$transaction_id = $result['number'];
+
+			$order->add_order_note(
+				\sprintf(
+				/* translators: 1: transaction 2: state 3: reason */                    __(
+					'Refund process has been executed from order admin. Transaction ID: %1$s. State: %2$s. Reason: %3$s', //phpcs:ignore
+					'swedbank-pay-payment-menu' //phpcs:ignore
+				), //phpcs:ignore
+					$transaction_id,
+					$result['state'],
+					empty( $reason ) ? '-' : $reason
+				)
+			);
+		}
 
 		$this->save_refunded_items( $order, $lines );
+
+		// Keep the refunded lines on the pending entry, so they can be rolled back if the reversal fails.
+		if ( $is_pending ) {
+			Swedbank_Pay()->async_reversal()->set_pending_field( $order, $result['payeeReference'], 'lines', $lines );
+		}
 
 		// Create Credit Memo.
 		if ( $create_credit_memo ) {
@@ -434,6 +443,11 @@ class Swedbank_Pay_Payment_Actions {
 					'restock_items'  => true,
 				)
 			);
+
+			if ( ! is_wp_error( $refund ) && $is_pending ) {
+				Swedbank_Pay()->async_reversal()->set_pending_field( $order, $result['payeeReference'], 'refund_id', $refund->get_id() );
+			}
+
 			if ( is_wp_error( $refund ) ) {
 				$context['error'] = join( '; ', $refund->get_error_messages() );
 				Swedbank_Pay()->logger()->error(

--- a/includes/class-swedbank-pay-payment-gateway-checkout.php
+++ b/includes/class-swedbank-pay-payment-gateway-checkout.php
@@ -857,6 +857,12 @@ class Swedbank_Pay_Payment_Gateway_Checkout extends WC_Payment_Gateway {
 			return new WP_Error( 'refund', __( 'Amount must be positive.', 'swedbank-pay-payment-menu' ) );
 		}
 
+		// Block new refunds while a previous reversal is awaiting confirmation from Swedbank Pay.
+		$pending_reversal_error = $this->api->maybe_block_pending_reversal( $order );
+		if ( is_wp_error( $pending_reversal_error ) ) {
+			return $pending_reversal_error;
+		}
+
 		// It uses transient `sb_refund_parameters_` to get items.
 		$args = get_transient( 'sb_refund_parameters_' . $order->get_id() );
 		if ( empty( $args ) ) {

--- a/includes/class-swedbank-pay-scheduler.php
+++ b/includes/class-swedbank-pay-scheduler.php
@@ -111,6 +111,17 @@ class Swedbank_Pay_Scheduler {
 			return false;
 		}
 
+		// Resolve any reversals that were accepted asynchronously (HTTP 202); the payee
+		// callback is the signal that their result is now available on the payment order.
+		$async_reversal = Swedbank_Pay()->async_reversal();
+		if ( $async_reversal->has_pending( $order ) ) {
+			$result = $async_reversal->check_pending_reversals( $order );
+			if ( is_wp_error( $result ) ) {
+				$context['error'] = $result->get_error_message();
+				Swedbank_Pay()->logger()->error( '[SCHEDULER]: Failed to check pending reversals.', $context );
+			}
+		}
+
 		// v3.1 callbacks no longer carry a transaction.number; finalize_payment falls back
 		// to the paymentOrder's `paid` resource to discover the right transaction.
 		// process_transaction() dedupes by financial transaction id internally.

--- a/src/AsyncReversal.php
+++ b/src/AsyncReversal.php
@@ -16,11 +16,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class AsyncReversal
  *
- * Some payment methods (e.g. Banklink in the Baltics) process reversals asynchronously.
- * The reversal request is then answered with HTTP 202 Accepted, the initialized reversal
- * transaction is not included in the response, and the final result arrives via a payee
- * callback. Successful reversals appear in the payment order's `financialTransactions`;
- * failed reversals appear in `postPurchaseFailedAttempts`.
+ * Some payment methods (e.g. Banklink in the Baltics) answer a reversal with HTTP 202 and report
+ * the outcome later. Confirmed reversals appear in `financialTransactions`, rejected ones in
+ * `postpurchaseFailedAttempts`.
  */
 class AsyncReversal {
 	use Traits\Singleton;
@@ -28,17 +26,12 @@ class AsyncReversal {
 	public const PENDING_REVERSALS_META = '_swedbank_pay_pending_reversals';
 
 	/**
-	 * Numbers of the failed post purchase attempts that have already been handled.
-	 *
-	 * Failed attempts carry no payeeReference, so they cannot be matched against a
-	 * pending entry directly. Remembering the ones we have seen is what keeps an older
-	 * failure from being attributed to a later reversal.
+	 * Handled failed attempt numbers, so an older failure is not attributed to a later reversal.
 	 */
 	public const SEEN_FAILED_ATTEMPTS_META = '_swedbank_pay_seen_failed_attempts';
 
 	/**
-	 * How much earlier than the pending entry a failed attempt may be created and still
-	 * be considered part of it, in seconds. Absorbs clock skew between us and Swedbank Pay.
+	 * Clock skew allowance, in seconds, when matching a failed attempt to a pending entry.
 	 */
 	private const FAILED_ATTEMPT_TOLERANCE = 300;
 
@@ -55,11 +48,7 @@ class AsyncReversal {
 	}
 
 	/**
-	 * Delays between the scheduled rechecks, in seconds.
-	 *
-	 * The callback is the primary signal; these rechecks only exist so a lost callback does
-	 * not leave a reversal pending forever. The ladder spans the three days Swedbank Pay
-	 * documents as the worst case for an asynchronous reversal.
+	 * Delays between rechecks, in seconds, spanning the three day worst case.
 	 *
 	 * @return int[]
 	 */
@@ -100,9 +89,7 @@ class AsyncReversal {
 			)
 		);
 
-		// Action Scheduler returns 0 when it could not store the action. Reporting that as a
-		// success would retire the safety net without telling anyone, leaving the reversal
-		// pending forever, so treat it as a failure and let the caller escalate instead.
+		// Action Scheduler returns 0 when it could not store the action.
 		if ( 0 === $action_id ) {
 			Swedbank_Pay()->logger()->error(
 				"[ASYNC REVERSAL]: Failed to schedule recheck attempt {$attempt} for order #{$order->get_order_number()}.",
@@ -256,10 +243,7 @@ class AsyncReversal {
 			)
 		);
 
-		// Safety net in case the payee callback never arrives. A failure here is logged by
-		// schedule_recheck() and left non-fatal on purpose: the reversal has been accepted, the
-		// callback is still the primary route, and maybe_block_pending_reversal() re-checks on
-		// the merchant's next payment action regardless.
+		// Safety net if the callback never arrives; non-fatal, schedule_recheck() logs a failure.
 		$this->schedule_recheck( $order, 0 );
 
 		Swedbank_Pay()->logger()->info( "[ASYNC REVERSAL]: Reversal accepted asynchronously (HTTP 202) for order #{$order->get_order_number()}. Awaiting confirmation via callback.", $context );
@@ -397,8 +381,16 @@ class AsyncReversal {
 
 		$seen = $this->get_seen_failed_attempts( $order );
 		foreach ( $failed_attempts as $attempt ) {
-			// The resource model calls this field `type`; tolerate `transactionType` in case it is aliased.
-			$type = $attempt['transactionType'] ?? $attempt['type'] ?? '';
+			// Unclear which field name is used; log rather than skip an attempt carrying neither.
+			if ( ! isset( $attempt['transactionType'] ) && ! isset( $attempt['type'] ) ) {
+				Swedbank_Pay()->logger()->error(
+					"[ASYNC REVERSAL]: Failed attempt for order #{$order->get_order_number()} has no recognised type field: " . wp_json_encode( $attempt ),
+					$context
+				);
+				continue;
+			}
+
+			$type = $attempt['transactionType'] ?? $attempt['type'];
 			if ( OrderManagement::TYPE_REVERSAL !== $type ) {
 				continue;
 			}
@@ -410,9 +402,7 @@ class AsyncReversal {
 				continue;
 			}
 
-			// A failed attempt has no payeeReference, so the pending entry it belongs to has
-			// to be inferred. Only one reversal can be pending at a time, so the oldest entry
-			// created no later than the attempt is the one that failed.
+			// A failed attempt carries no payeeReference, so infer which entry it belongs to.
 			$entry_reference = $this->match_pending_to_attempt( $pending, $attempt );
 
 			if ( '' !== $number ) {
@@ -441,39 +431,32 @@ class AsyncReversal {
 	/**
 	 * Retrieve the post purchase failed attempts for a payment order.
 	 *
-	 * The paymentOrder resource advertises this sub-resource as `postpurchasefailedattempts`,
-	 * while the resource model documents the endpoint as `failedpostpurchaseattempts`. Try the
-	 * advertised spelling first and fall back to the documented one.
+	 * Note the lowercase p in "purchase"; the SDK's link stub docblock spells it differently to
+	 * the API.
 	 *
 	 * @param \SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Api $api The API instance.
 	 * @param \WC_Order                                          $order The order, used for logging.
 	 * @param string                                             $payment_order_id The payment order ID.
 	 *
-	 * @return array|\WP_Error The list of failed attempts, or WP_Error when neither endpoint answered.
+	 * @return array|\WP_Error The failed attempts, or WP_Error on a failed request or unknown shape.
 	 */
 	private function get_failed_attempts( $api, \WC_Order $order, $payment_order_id ) {
-		$endpoints = array( 'postpurchasefailedattempts', 'failedpostpurchaseattempts' );
-
-		$result = null;
-		foreach ( $endpoints as $endpoint ) {
-			LogUtility::$title = "[ASYNC REVERSAL]: Retrieve {$endpoint} for order #{$order->get_order_number()}";
-			$result            = $api->request( 'GET', "{$payment_order_id}/{$endpoint}" );
-			if ( ! is_wp_error( $result ) ) {
-				break;
-			}
-		}
+		LogUtility::$title = "[ASYNC REVERSAL]: Retrieve postpurchasefailedattempts for order #{$order->get_order_number()}";
+		$result            = $api->request( 'GET', "{$payment_order_id}/postpurchasefailedattempts" );
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
-		$container = $result['postPurchaseFailedAttempts'] ?? $result['failedPostPurchaseAttempts'] ?? $result;
+		// Erroring keeps the reversal pending; reading an unknown shape as "no failures" would lose it.
+		if ( ! isset( $result['postpurchaseFailedAttempts']['postpurchaseFailedAttemptList'] ) ) {
+			return new \WP_Error(
+				'unexpected_response',
+				'The postpurchasefailedattempts response did not contain postpurchaseFailedAttempts.postpurchaseFailedAttemptList.'
+			);
+		}
 
-		// The documented list key is `postpurchaseFailedAttemptList`; the others are tolerated aliases.
-		$list = $container['postpurchaseFailedAttemptList']
-			?? $container['postPurchaseFailedAttemptList']
-			?? $container['failedAttemptList']
-			?? array();
+		$list = $result['postpurchaseFailedAttempts']['postpurchaseFailedAttemptList'];
 
 		return is_array( $list ) ? $list : array();
 	}

--- a/src/AsyncReversal.php
+++ b/src/AsyncReversal.php
@@ -1,0 +1,682 @@
+<?php
+/**
+ * Class AsyncReversal
+ *
+ * Handles asynchronous reversals (refunds) that are accepted with HTTP 202 and
+ * confirmed later through a payee callback.
+ */
+
+namespace Krokedil\Swedbank\Pay;
+
+use Krokedil\Swedbank\Pay\Utility\LogUtility;
+use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Order_Item;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AsyncReversal
+ *
+ * Some payment methods (e.g. Banklink in the Baltics) process reversals asynchronously.
+ * The reversal request is then answered with HTTP 202 Accepted, the initialized reversal
+ * transaction is not included in the response, and the final result arrives via a payee
+ * callback. Successful reversals appear in the payment order's `financialTransactions`;
+ * failed reversals appear in `postPurchaseFailedAttempts`.
+ */
+class AsyncReversal {
+	use Traits\Singleton;
+
+	public const PENDING_REVERSALS_META = '_swedbank_pay_pending_reversals';
+
+	/**
+	 * Numbers of the failed post purchase attempts that have already been handled.
+	 *
+	 * Failed attempts carry no payeeReference, so they cannot be matched against a
+	 * pending entry directly. Remembering the ones we have seen is what keeps an older
+	 * failure from being attributed to a later reversal.
+	 */
+	public const SEEN_FAILED_ATTEMPTS_META = '_swedbank_pay_seen_failed_attempts';
+
+	/**
+	 * How much earlier than the pending entry a failed attempt may be created and still
+	 * be considered part of it, in seconds. Absorbs clock skew between us and Swedbank Pay.
+	 */
+	private const FAILED_ATTEMPT_TOLERANCE = 300;
+
+	/**
+	 * Action Scheduler hook for rechecking a reversal whose callback has not arrived.
+	 */
+	public const RECHECK_HOOK = 'swedbank_pay_recheck_pending_reversals';
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		add_action( self::RECHECK_HOOK, array( $this, 'handle_recheck' ), 10, 2 );
+	}
+
+	/**
+	 * Delays between the scheduled rechecks, in seconds.
+	 *
+	 * The callback is the primary signal; these rechecks only exist so a lost callback does
+	 * not leave a reversal pending forever. The ladder spans the three days Swedbank Pay
+	 * documents as the worst case for an asynchronous reversal.
+	 *
+	 * @return int[]
+	 */
+	private function get_recheck_delays() {
+		/**
+		 * Filter the delays between rechecks of a pending asynchronous reversal.
+		 *
+		 * @param int[] $delays Delays in seconds, one per recheck attempt.
+		 */
+		$delays = apply_filters(
+			'swedbank_pay_pending_reversal_recheck_delays',
+			array( 5 * MINUTE_IN_SECONDS, 30 * MINUTE_IN_SECONDS, 2 * HOUR_IN_SECONDS, 8 * HOUR_IN_SECONDS, DAY_IN_SECONDS, DAY_IN_SECONDS, DAY_IN_SECONDS )
+		);
+
+		return array_values( array_filter( array_map( 'intval', (array) $delays ) ) );
+	}
+
+	/**
+	 * Schedule the next recheck of an order's pending reversals.
+	 *
+	 * @param \WC_Order $order The order.
+	 * @param int       $attempt The recheck attempt to schedule, zero based.
+	 *
+	 * @return bool Whether a recheck was scheduled.
+	 */
+	private function schedule_recheck( \WC_Order $order, $attempt ) {
+		$delays = $this->get_recheck_delays();
+		if ( ! isset( $delays[ $attempt ] ) ) {
+			return false;
+		}
+
+		as_schedule_single_action(
+			time() + $delays[ $attempt ],
+			self::RECHECK_HOOK,
+			array(
+				'order_id' => $order->get_id(),
+				'attempt'  => $attempt,
+			)
+		);
+
+		return true;
+	}
+
+	/**
+	 * Recheck an order's pending reversals when the callback has not arrived.
+	 *
+	 * @param int $order_id The order to recheck.
+	 * @param int $attempt The recheck attempt that is running, zero based.
+	 *
+	 * @return void
+	 */
+	public function handle_recheck( $order_id, $attempt = 0 ) {
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof \WC_Order || ! $this->has_pending( $order ) ) {
+			return;
+		}
+
+		$context = array(
+			'action'   => 'recheck_pending_reversals',
+			'order_id' => $order->get_id(),
+			'attempt'  => $attempt,
+		);
+
+		$result = $this->check_pending_reversals( $order );
+		if ( is_wp_error( $result ) ) {
+			$context['error'] = $result->get_error_message();
+			Swedbank_Pay()->logger()->error( "[ASYNC REVERSAL]: Recheck failed for order #{$order->get_order_number()}: {$result->get_error_message()}", $context );
+		}
+
+		// Resolved, either just now or by a callback that arrived in the meantime.
+		if ( ! $this->has_pending( $order ) ) {
+			return;
+		}
+
+		// Retry until the documented three day window is exhausted, then hand it to the merchant.
+		if ( ! $this->schedule_recheck( $order, (int) $attempt + 1 ) ) {
+			$this->abandon_pending( $order );
+		}
+	}
+
+	/**
+	 * Give up on reversals that Swedbank Pay never reported an outcome for.
+	 *
+	 * Puts the order on hold so the merchant verifies it manually, and drops the pending
+	 * entries so the order is not blocked from further payment actions indefinitely.
+	 *
+	 * @param \WC_Order $order The order.
+	 *
+	 * @return void
+	 */
+	private function abandon_pending( \WC_Order $order ) {
+		$order->read_meta_data();
+		$pending = $this->get_pending( $order );
+
+		$context = array(
+			'action'           => 'abandon_pending_reversals',
+			'order_id'         => $order->get_id(),
+			'order_number'     => $order->get_order_number(),
+			'payment_order_id' => $order->get_meta( '_payex_paymentorder_id' ),
+			'pending'          => array_keys( $pending ),
+		);
+
+		Swedbank_Pay()->logger()->error( "[ASYNC REVERSAL]: Giving up on unconfirmed reversal(s) for order #{$order->get_order_number()}.", $context );
+
+		$this->save_pending( $order, array() );
+
+		$message = __( 'Swedbank Pay never confirmed whether the refund succeeded. Please verify the refund with Swedbank Pay before taking any further action on this order.', 'swedbank-pay-payment-menu' );
+
+		$gateway = swedbank_pay_get_payment_method( $order );
+		if ( $gateway && property_exists( $gateway, 'api' ) ) {
+			$gateway->api->update_order_status( $order, 'on-hold', $order->get_transaction_id(), $message );
+		} else {
+			$order->update_status( 'on-hold', $message );
+		}
+	}
+
+	/**
+	 * Register a reversal that was accepted (HTTP 202) but not yet confirmed.
+	 *
+	 * Stores a pending entry on the order, keyed by the payeeReference sent in the
+	 * reversal request, and returns a synthetic transaction array so callers treat
+	 * the refund as successfully submitted.
+	 *
+	 * @param \WC_Order             $order The order being refunded.
+	 * @param object                $transaction_data The TransactionData object sent in the reversal request.
+	 * @param string                $mode 'amount' or 'items'.
+	 * @param \WC_Order_Refund|null $refund_order The WC refund connected to the reversal, if known.
+	 *
+	 * @return array Synthetic transaction array with `state` = 'Pending' and `pending` = true.
+	 */
+	public function init_pending( \WC_Order $order, $transaction_data, $mode, $refund_order = null ) {
+		$payee_reference = $transaction_data->getPayeeReference();
+		$amount          = $transaction_data->getAmount();
+
+		$refund_id = 0;
+		if ( $refund_order instanceof \WC_Order_Refund ) {
+			$refund_id = $refund_order->get_id();
+		} else {
+			// WooCommerce creates the refund before the gateway's process_refund() runs.
+			$refunds = $order->get_refunds();
+			$refund  = reset( $refunds );
+			if ( $refund instanceof \WC_Order_Refund ) {
+				$refund_id = $refund->get_id();
+			}
+		}
+
+		$context = array(
+			'action'           => 'init_pending_reversal',
+			'order_id'         => $order->get_id(),
+			'order_number'     => $order->get_order_number(),
+			'payment_order_id' => $order->get_meta( '_payex_paymentorder_id' ),
+			'payee_reference'  => $payee_reference,
+			'amount'           => $amount,
+			'refund_id'        => $refund_id,
+			'mode'             => $mode,
+		);
+
+		// Reload order meta to ensure we have the latest changes and avoid conflicts from parallel scripts.
+		$order->read_meta_data();
+		$pending = $this->get_pending( $order );
+
+		$pending[ $payee_reference ] = array(
+			'amount'    => $amount,
+			'created'   => gmdate( 'c' ),
+			'refund_id' => $refund_id,
+			'mode'      => $mode,
+			'lines'     => null,
+		);
+
+		$order->update_meta_data( self::PENDING_REVERSALS_META, $pending );
+		$order->save_meta_data();
+
+		$order->add_order_note(
+			sprintf(
+				// translators: %s: refund amount.
+				__( 'The refund of %s has been sent to Swedbank Pay and is awaiting confirmation. This usually takes less than a minute, but can in rare cases take up to 3 days.', 'swedbank-pay-payment-menu' ),
+				wc_price( $amount / 100, array( 'currency' => $order->get_currency() ) )
+			)
+		);
+
+		// Safety net in case the payee callback never arrives.
+		$this->schedule_recheck( $order, 0 );
+
+		Swedbank_Pay()->logger()->info( "[ASYNC REVERSAL]: Reversal accepted asynchronously (HTTP 202) for order #{$order->get_order_number()}. Awaiting confirmation via callback.", $context );
+
+		return array(
+			'number'         => '',
+			'type'           => OrderManagement::TYPE_REVERSAL,
+			'state'          => 'Pending',
+			'amount'         => $amount,
+			'created'        => gmdate( 'c' ),
+			'updated'        => gmdate( 'c' ),
+			'description'    => sprintf( 'Refund Order #%s', $order->get_order_number() ),
+			'payeeReference' => $payee_reference,
+			'pending'        => true,
+		);
+	}
+
+	/**
+	 * Whether the order has reversals awaiting confirmation.
+	 *
+	 * @param \WC_Order $order The order to check.
+	 *
+	 * @return bool
+	 */
+	public function has_pending( \WC_Order $order ) {
+		return ! empty( $this->get_pending( $order ) );
+	}
+
+	/**
+	 * Update a single field on a pending reversal entry.
+	 *
+	 * @param \WC_Order $order The order.
+	 * @param string    $payee_reference The pending entry key.
+	 * @param string    $field The field to set.
+	 * @param mixed     $value The value to set.
+	 *
+	 * @return void
+	 */
+	public function set_pending_field( \WC_Order $order, $payee_reference, $field, $value ) {
+		$order->read_meta_data();
+		$pending = $this->get_pending( $order );
+		if ( ! isset( $pending[ $payee_reference ] ) ) {
+			return;
+		}
+
+		$pending[ $payee_reference ][ $field ] = $value;
+		$order->update_meta_data( self::PENDING_REVERSALS_META, $pending );
+		$order->save_meta_data();
+	}
+
+	/**
+	 * Resolve pending reversals against the payment order.
+	 *
+	 * Confirmed reversals are found in `financialTransactions` and processed through the
+	 * regular transaction handling. Failed reversals are found in `postPurchaseFailedAttempts`
+	 * and put the order on hold. Entries that appear in neither are left pending.
+	 *
+	 * @param \WC_Order $order The order to check.
+	 *
+	 * @return true|\WP_Error True when nothing is left to do (including nothing pending).
+	 */
+	public function check_pending_reversals( \WC_Order $order ) {
+		$order->read_meta_data();
+		$pending = $this->get_pending( $order );
+		if ( empty( $pending ) ) {
+			return true;
+		}
+
+		$payment_order_id = $order->get_meta( '_payex_paymentorder_id' );
+		if ( empty( $payment_order_id ) ) {
+			return new \WP_Error( 'missing_payment_id', 'Payment order ID is unknown.' );
+		}
+
+		$gateway = swedbank_pay_get_payment_method( $order );
+		if ( ! $gateway || ! property_exists( $gateway, 'api' ) ) {
+			return new \WP_Error( 'missing_gateway', 'Unable to retrieve the payment gateway instance.' );
+		}
+		$api = $gateway->api;
+
+		$context = array(
+			'action'           => 'check_pending_reversals',
+			'order_id'         => $order->get_id(),
+			'order_number'     => $order->get_order_number(),
+			'payment_order_id' => $payment_order_id,
+			'pending'          => array_keys( $pending ),
+		);
+
+		// Check confirmed reversals in the financial transactions list.
+		LogUtility::$title = "[ASYNC REVERSAL]: Retrieve financial transactions for order #{$order->get_order_number()}";
+		$result            = $api->request( 'GET', "{$payment_order_id}/financialtransactions" );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$transactions_list = $result['financialTransactions']['financialTransactionsList'] ?? array();
+		foreach ( $transactions_list as $transaction ) {
+			if ( OrderManagement::TYPE_REVERSAL !== ( $transaction['type'] ?? '' ) ) {
+				continue;
+			}
+
+			$payee_reference = $transaction['payeeReference'] ?? '';
+			if ( ! isset( $pending[ $payee_reference ] ) ) {
+				continue;
+			}
+
+			$process_result = $api->process_transaction( $order, $transaction );
+			if ( is_wp_error( $process_result ) ) {
+				Swedbank_Pay()->logger()->error( "[ASYNC REVERSAL]: Failed to process confirmed reversal #{$transaction['number']} for order #{$order->get_order_number()}: {$process_result->get_error_message()}", $context );
+				continue;
+			}
+
+			unset( $pending[ $payee_reference ] );
+			$this->save_pending( $order, $pending );
+
+			$order->add_order_note(
+				sprintf(
+					// translators: %s: refund amount.
+					__( 'Swedbank Pay has confirmed the refund of %s. The money is on its way back to the customer.', 'swedbank-pay-payment-menu' ),
+					wc_price( $transaction['amount'] / 100, array( 'currency' => $order->get_currency() ) )
+				)
+			);
+
+			Swedbank_Pay()->logger()->info( "[ASYNC REVERSAL]: Reversal confirmed for order #{$order->get_order_number()}. Transaction: #{$transaction['number']}.", $context );
+		}
+
+		if ( empty( $pending ) ) {
+			return true;
+		}
+
+		// Check failed reversals in the post purchase failed attempts list.
+		$failed_attempts = $this->get_failed_attempts( $api, $order, $payment_order_id );
+		if ( is_wp_error( $failed_attempts ) ) {
+			return $failed_attempts;
+		}
+
+		$seen = $this->get_seen_failed_attempts( $order );
+		foreach ( $failed_attempts as $attempt ) {
+			// The resource model calls this field `type`; tolerate `transactionType` in case it is aliased.
+			$type = $attempt['transactionType'] ?? $attempt['type'] ?? '';
+			if ( OrderManagement::TYPE_REVERSAL !== $type ) {
+				continue;
+			}
+
+			$number = (string) ( $attempt['number'] ?? '' );
+
+			// Already handled on an earlier callback for this order.
+			if ( '' !== $number && in_array( $number, $seen, true ) ) {
+				continue;
+			}
+
+			// A failed attempt has no payeeReference, so the pending entry it belongs to has
+			// to be inferred. Only one reversal can be pending at a time, so the oldest entry
+			// created no later than the attempt is the one that failed.
+			$entry_reference = $this->match_pending_to_attempt( $pending, $attempt );
+
+			if ( '' !== $number ) {
+				$seen[] = $number;
+			}
+
+			if ( null === $entry_reference ) {
+				continue;
+			}
+
+			$entry = $pending[ $entry_reference ];
+			unset( $pending[ $entry_reference ] );
+			$this->save_pending( $order, $pending );
+
+			$this->handle_failed_reversal( $order, $entry_reference, $entry, $attempt );
+		}
+		$this->save_seen_failed_attempts( $order, $seen );
+
+		if ( ! empty( $pending ) ) {
+			Swedbank_Pay()->logger()->debug( '[ASYNC REVERSAL]: Reversal(s) still awaiting confirmation: ' . implode( ', ', array_keys( $pending ) ), $context );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieve the post purchase failed attempts for a payment order.
+	 *
+	 * The paymentOrder resource advertises this sub-resource as `postpurchasefailedattempts`,
+	 * while the resource model documents the endpoint as `failedpostpurchaseattempts`. Try the
+	 * advertised spelling first and fall back to the documented one.
+	 *
+	 * @param \SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Api $api The API instance.
+	 * @param \WC_Order                                          $order The order, used for logging.
+	 * @param string                                             $payment_order_id The payment order ID.
+	 *
+	 * @return array|\WP_Error The list of failed attempts, or WP_Error when neither endpoint answered.
+	 */
+	private function get_failed_attempts( $api, \WC_Order $order, $payment_order_id ) {
+		$endpoints = array( 'postpurchasefailedattempts', 'failedpostpurchaseattempts' );
+
+		$result = null;
+		foreach ( $endpoints as $endpoint ) {
+			LogUtility::$title = "[ASYNC REVERSAL]: Retrieve {$endpoint} for order #{$order->get_order_number()}";
+			$result            = $api->request( 'GET', "{$payment_order_id}/{$endpoint}" );
+			if ( ! is_wp_error( $result ) ) {
+				break;
+			}
+		}
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$container = $result['postPurchaseFailedAttempts'] ?? $result['failedPostPurchaseAttempts'] ?? $result;
+
+		// The documented list key is `postpurchaseFailedAttemptList`; the others are tolerated aliases.
+		$list = $container['postpurchaseFailedAttemptList']
+			?? $container['postPurchaseFailedAttemptList']
+			?? $container['failedAttemptList']
+			?? array();
+
+		return is_array( $list ) ? $list : array();
+	}
+
+	/**
+	 * Find the pending entry a failed attempt belongs to.
+	 *
+	 * @param array $pending The pending entries, keyed by payeeReference.
+	 * @param array $attempt The failed attempt from Swedbank Pay.
+	 *
+	 * @return string|null The payeeReference of the matching entry, or null when none matches.
+	 */
+	private function match_pending_to_attempt( array $pending, array $attempt ) {
+		$attempt_created = strtotime( $attempt['created'] ?? '' );
+
+		$match         = null;
+		$match_created = null;
+		foreach ( $pending as $payee_reference => $entry ) {
+			$entry_created = strtotime( $entry['created'] ?? '' );
+
+			// Ignore attempts that predate the reversal; they belong to an earlier refund.
+			if ( false !== $attempt_created && false !== $entry_created
+				&& $attempt_created < $entry_created - self::FAILED_ATTEMPT_TOLERANCE
+			) {
+				continue;
+			}
+
+			if ( null === $match_created || ( false !== $entry_created && $entry_created < $match_created ) ) {
+				$match         = (string) $payee_reference;
+				$match_created = $entry_created;
+			}
+		}
+
+		return $match;
+	}
+
+	/**
+	 * Get the failed attempt numbers that have already been handled for an order.
+	 *
+	 * @param \WC_Order $order The order.
+	 *
+	 * @return array
+	 */
+	private function get_seen_failed_attempts( \WC_Order $order ) {
+		$seen = $order->get_meta( self::SEEN_FAILED_ATTEMPTS_META );
+
+		return empty( $seen ) ? array() : array_map( 'strval', (array) $seen );
+	}
+
+	/**
+	 * Persist the handled failed attempt numbers.
+	 *
+	 * @param \WC_Order $order The order.
+	 * @param array     $seen The failed attempt numbers.
+	 *
+	 * @return void
+	 */
+	private function save_seen_failed_attempts( \WC_Order $order, array $seen ) {
+		$order->update_meta_data( self::SEEN_FAILED_ATTEMPTS_META, array_values( array_unique( $seen ) ) );
+		$order->save_meta_data();
+	}
+
+	/**
+	 * Handle a reversal that Swedbank Pay reported as failed.
+	 *
+	 * Puts the order on hold to alert the merchant and removes the WooCommerce refund
+	 * so that the order totals are correct and the refund can be retried.
+	 *
+	 * @param \WC_Order $order The order.
+	 * @param string    $payee_reference The payee reference of the failed reversal.
+	 * @param array     $entry The pending reversal entry.
+	 * @param array     $attempt The failed attempt data from Swedbank Pay.
+	 *
+	 * @return void
+	 */
+	private function handle_failed_reversal( \WC_Order $order, $payee_reference, array $entry, array $attempt ) {
+		$context = array(
+			'action'           => 'handle_failed_reversal',
+			'order_id'         => $order->get_id(),
+			'order_number'     => $order->get_order_number(),
+			'payment_order_id' => $order->get_meta( '_payex_paymentorder_id' ),
+			'payee_reference'  => $payee_reference,
+			'entry'            => $entry,
+			'failed_attempt'   => $attempt,
+		);
+
+		Swedbank_Pay()->logger()->error( "[ASYNC REVERSAL]: Reversal failed for order #{$order->get_order_number()}. Failed attempt: " . wp_json_encode( $attempt ), $context );
+
+		$message = sprintf(
+			// translators: %s: refund amount.
+			__( 'The refund of %s could not be completed by Swedbank Pay. No money has been returned to the customer. The order has been set to on hold so you can review it and try the refund again.', 'swedbank-pay-payment-menu' ),
+			wc_price( $entry['amount'] / 100, array( 'currency' => $order->get_currency() ) )
+		);
+
+		$gateway = swedbank_pay_get_payment_method( $order );
+		if ( $gateway && property_exists( $gateway, 'api' ) ) {
+			$gateway->api->update_order_status( $order, 'on-hold', $order->get_transaction_id(), $message );
+		} else {
+			$order->update_status( 'on-hold', $message );
+		}
+
+		/**
+		 * Whether to remove the WooCommerce refund when Swedbank Pay rejected the reversal.
+		 *
+		 * Defaults to keeping it, which is how the other Krokedil gateways behave: the refund
+		 * stands, the order goes on hold, and the merchant decides what to do. Returning true
+		 * removes the refund so the order totals match the money actually moved, at the cost
+		 * of leaving any stock adjustments behind.
+		 *
+		 * @param bool      $delete Whether to delete the refund. Default false.
+		 * @param \WC_Order $order The order the reversal failed for.
+		 * @param array     $entry The pending reversal entry.
+		 */
+		$delete_refund = apply_filters( 'swedbank_pay_delete_failed_refund', false, $order, $entry );
+
+		if ( ! $delete_refund ) {
+			return;
+		}
+
+		if ( ! empty( $entry['refund_id'] ) ) {
+			$refund = wc_get_order( $entry['refund_id'] );
+			if ( $refund instanceof \WC_Order_Refund && $refund->get_parent_id() === $order->get_id() ) {
+				$refund->delete( true );
+				$order->add_order_note(
+					__( 'The refund entry was removed from the order so the order totals are correct. If any items were returned to stock, please adjust the stock manually.', 'swedbank-pay-payment-menu' )
+				);
+			}
+		}
+
+		// Only roll back the plugin's own refunded-items tracking when the refund itself was
+		// removed; otherwise the lines would be refundable again while the refund still stands.
+		if ( 'items' === ( $entry['mode'] ?? '' ) && ! empty( $entry['lines'] ) ) {
+			$this->rollback_refunded_items( $order, (array) $entry['lines'] );
+		}
+	}
+
+	/**
+	 * Subtract the given refund lines from the `_payex_refunded_items` meta.
+	 *
+	 * Inverse of Swedbank_Pay_Payment_Actions::save_refunded_items(); without this a failed
+	 * items refund would permanently block the lines from being refunded again.
+	 *
+	 * @param \WC_Order $order The order.
+	 * @param array     $lines The refund lines (keyed by order item ID, each with a 'qty').
+	 *
+	 * @return void
+	 */
+	private function rollback_refunded_items( \WC_Order $order, array $lines ) {
+		$current_items = $order->get_meta( '_payex_refunded_items' );
+		$current_items = empty( $current_items ) ? array() : (array) $current_items;
+		if ( empty( $current_items ) ) {
+			return;
+		}
+
+		foreach ( $lines as $item_id => $line ) {
+			$qty = max( 1, (int) ( $line['qty'] ?? 1 ) );
+
+			$item = $order->get_item( $item_id );
+			if ( ! $item ) {
+				continue;
+			}
+
+			switch ( $item->get_type() ) {
+				case 'line_item':
+					// The item is a WC_Order_Item_Product here, so get_product() is available.
+					$product   = $item->get_product();
+					$reference = $product ? $product->get_sku() : 'other';
+					break;
+				case 'shipping':
+				case 'fee':
+				case 'coupon':
+					$reference = $item->get_type();
+					break;
+				default:
+					$reference = 'other';
+					break;
+			}
+
+			foreach ( $current_items as $key => &$current_item ) {
+				if ( ( $current_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] ?? '' ) === $reference ) {
+					$current_item[ Swedbank_Pay_Order_Item::FIELD_QTY ] -= $qty;
+					if ( $current_item[ Swedbank_Pay_Order_Item::FIELD_QTY ] <= 0 ) {
+						unset( $current_items[ $key ] );
+					}
+					break;
+				}
+			}
+			unset( $current_item );
+		}
+
+		$order->update_meta_data( '_payex_refunded_items', array_values( $current_items ) );
+		$order->save_meta_data();
+	}
+
+	/**
+	 * Get the pending reversal entries for an order.
+	 *
+	 * @param \WC_Order $order The order.
+	 *
+	 * @return array
+	 */
+	private function get_pending( \WC_Order $order ) {
+		$pending = $order->get_meta( self::PENDING_REVERSALS_META );
+
+		return empty( $pending ) ? array() : (array) $pending;
+	}
+
+	/**
+	 * Persist the pending reversal entries, removing the meta when empty.
+	 *
+	 * @param \WC_Order $order The order.
+	 * @param array     $pending The pending entries to save.
+	 *
+	 * @return void
+	 */
+	private function save_pending( \WC_Order $order, array $pending ) {
+		if ( empty( $pending ) ) {
+			$order->delete_meta_data( self::PENDING_REVERSALS_META );
+		} else {
+			$order->update_meta_data( self::PENDING_REVERSALS_META, $pending );
+		}
+
+		$order->save_meta_data();
+	}
+}

--- a/src/AsyncReversal.php
+++ b/src/AsyncReversal.php
@@ -36,6 +36,26 @@ class AsyncReversal {
 	 */
 	public function __construct() {
 		add_action( self::RECHECK_HOOK, array( $this, 'handle_recheck' ), 10, 2 );
+		add_filter( 'woocommerce_order_fully_refunded_status', array( $this, 'fully_refunded_status' ), 10, 2 );
+	}
+
+	/**
+	 * Hold a fully refunded order rather than marking it refunded before Swedbank Pay confirms.
+	 *
+	 * @param string $status The status WooCommerce is about to set.
+	 * @param int    $order_id The order being refunded.
+	 *
+	 * @return string
+	 */
+	public function fully_refunded_status( $status, $order_id ) {
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof \WC_Order || ! $this->has_pending( $order ) ) {
+			return $status;
+		}
+
+		// Refunded would claim the money is back before anyone knows that. Confirmation moves the
+		// order on to refunded; rejection and giving up both leave it on hold with a reason.
+		return 'on-hold';
 	}
 
 	/**

--- a/src/AsyncReversal.php
+++ b/src/AsyncReversal.php
@@ -2,23 +2,19 @@
 /**
  * Class AsyncReversal
  *
- * Handles asynchronous reversals (refunds) that are accepted with HTTP 202 and
- * confirmed later through a payee callback.
+ * Some payment methods (e.g. Banklink in the Baltics) answer a reversal with HTTP 202 and report
+ * the outcome later. Confirmed reversals appear in `financialTransactions`, rejected ones in
+ * `postpurchaseFailedAttempts`. Reversal specific on purpose: nothing else returns 202 today.
  */
 
 namespace Krokedil\Swedbank\Pay;
 
 use Krokedil\Swedbank\Pay\Utility\LogUtility;
-use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Order_Item;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class AsyncReversal
- *
- * Some payment methods (e.g. Banklink in the Baltics) answer a reversal with HTTP 202 and report
- * the outcome later. Confirmed reversals appear in `financialTransactions`, rejected ones in
- * `postpurchaseFailedAttempts`.
+ * Registers reversals awaiting confirmation and resolves them against the payment order.
  */
 class AsyncReversal {
 	use Traits\Singleton;
@@ -26,19 +22,14 @@ class AsyncReversal {
 	public const PENDING_REVERSALS_META = '_swedbank_pay_pending_reversals';
 
 	/**
-	 * Handled failed attempt numbers, so an older failure is not attributed to a later reversal.
+	 * Action Scheduler hook for rechecking a reversal whose callback has not arrived.
 	 */
-	public const SEEN_FAILED_ATTEMPTS_META = '_swedbank_pay_seen_failed_attempts';
+	public const RECHECK_HOOK = 'swedbank_pay_recheck_pending_reversals';
 
 	/**
 	 * Clock skew allowance, in seconds, when matching a failed attempt to a pending entry.
 	 */
 	private const FAILED_ATTEMPT_TOLERANCE = 300;
-
-	/**
-	 * Action Scheduler hook for rechecking a reversal whose callback has not arrived.
-	 */
-	public const RECHECK_HOOK = 'swedbank_pay_recheck_pending_reversals';
 
 	/**
 	 * Class constructor.
@@ -53,17 +44,7 @@ class AsyncReversal {
 	 * @return int[]
 	 */
 	private function get_recheck_delays() {
-		/**
-		 * Filter the delays between rechecks of a pending asynchronous reversal.
-		 *
-		 * @param int[] $delays Delays in seconds, one per recheck attempt.
-		 */
-		$delays = apply_filters(
-			'swedbank_pay_pending_reversal_recheck_delays',
-			array( 5 * MINUTE_IN_SECONDS, 30 * MINUTE_IN_SECONDS, 2 * HOUR_IN_SECONDS, 8 * HOUR_IN_SECONDS, DAY_IN_SECONDS, DAY_IN_SECONDS, DAY_IN_SECONDS )
-		);
-
-		return array_values( array_filter( array_map( 'intval', (array) $delays ) ) );
+		return array( 5 * MINUTE_IN_SECONDS, 30 * MINUTE_IN_SECONDS, 2 * HOUR_IN_SECONDS, 8 * HOUR_IN_SECONDS, DAY_IN_SECONDS, DAY_IN_SECONDS, DAY_IN_SECONDS );
 	}
 
 	/**
@@ -120,16 +101,17 @@ class AsyncReversal {
 			return;
 		}
 
-		$context = array(
-			'action'   => 'recheck_pending_reversals',
-			'order_id' => $order->get_id(),
-			'attempt'  => $attempt,
-		);
-
 		$result = $this->check_pending_reversals( $order );
 		if ( is_wp_error( $result ) ) {
-			$context['error'] = $result->get_error_message();
-			Swedbank_Pay()->logger()->error( "[ASYNC REVERSAL]: Recheck failed for order #{$order->get_order_number()}: {$result->get_error_message()}", $context );
+			Swedbank_Pay()->logger()->error(
+				"[ASYNC REVERSAL]: Recheck failed for order #{$order->get_order_number()}: {$result->get_error_message()}",
+				array(
+					'action'   => 'recheck_pending_reversals',
+					'order_id' => $order->get_id(),
+					'attempt'  => $attempt,
+					'error'    => $result->get_error_message(),
+				)
+			);
 		}
 
 		// Resolved, either just now or by a callback that arrived in the meantime.
@@ -137,7 +119,6 @@ class AsyncReversal {
 			return;
 		}
 
-		// Retry until the documented three day window is exhausted, then hand it to the merchant.
 		if ( ! $this->schedule_recheck( $order, (int) $attempt + 1 ) ) {
 			$this->abandon_pending( $order );
 		}
@@ -146,94 +127,52 @@ class AsyncReversal {
 	/**
 	 * Give up on reversals that Swedbank Pay never reported an outcome for.
 	 *
-	 * Puts the order on hold so the merchant verifies it manually, and drops the pending
-	 * entries so the order is not blocked from further payment actions indefinitely.
-	 *
 	 * @param \WC_Order $order The order.
 	 *
 	 * @return void
 	 */
 	private function abandon_pending( \WC_Order $order ) {
-		$order->read_meta_data();
-		$pending = $this->get_pending( $order );
-
-		$context = array(
-			'action'           => 'abandon_pending_reversals',
-			'order_id'         => $order->get_id(),
-			'order_number'     => $order->get_order_number(),
-			'payment_order_id' => $order->get_meta( '_payex_paymentorder_id' ),
-			'pending'          => array_keys( $pending ),
+		Swedbank_Pay()->logger()->error(
+			"[ASYNC REVERSAL]: Giving up on unconfirmed reversal(s) for order #{$order->get_order_number()}.",
+			array(
+				'action'           => 'abandon_pending_reversals',
+				'order_id'         => $order->get_id(),
+				'order_number'     => $order->get_order_number(),
+				'payment_order_id' => $order->get_meta( '_payex_paymentorder_id' ),
+				'pending'          => array_keys( $this->get_pending( $order ) ),
+			)
 		);
 
-		Swedbank_Pay()->logger()->error( "[ASYNC REVERSAL]: Giving up on unconfirmed reversal(s) for order #{$order->get_order_number()}.", $context );
-
+		// Drop the entries too, so the order is not blocked from further payment actions forever.
 		$this->save_pending( $order, array() );
 
-		$message = __( 'Swedbank Pay never confirmed whether the refund succeeded. Please verify the refund with Swedbank Pay before taking any further action on this order.', 'swedbank-pay-payment-menu' );
-
-		$gateway = swedbank_pay_get_payment_method( $order );
-		if ( $gateway && property_exists( $gateway, 'api' ) ) {
-			$gateway->api->update_order_status( $order, 'on-hold', $order->get_transaction_id(), $message );
-		} else {
-			$order->update_status( 'on-hold', $message );
-		}
+		$this->set_on_hold(
+			$order,
+			__( 'Swedbank Pay never confirmed whether the refund succeeded. Please verify the refund with Swedbank Pay before taking any further action on this order.', 'swedbank-pay-payment-menu' )
+		);
 	}
 
 	/**
 	 * Register a reversal that was accepted (HTTP 202) but not yet confirmed.
 	 *
-	 * Stores a pending entry on the order, keyed by the payeeReference sent in the
-	 * reversal request, and returns a synthetic transaction array so callers treat
-	 * the refund as successfully submitted.
+	 * @param \WC_Order $order The order being refunded.
+	 * @param object    $transaction_data The TransactionData object sent in the reversal request.
 	 *
-	 * @param \WC_Order             $order The order being refunded.
-	 * @param object                $transaction_data The TransactionData object sent in the reversal request.
-	 * @param string                $mode 'amount' or 'items'.
-	 * @param \WC_Order_Refund|null $refund_order The WC refund connected to the reversal, if known.
-	 *
-	 * @return array Synthetic transaction array with `state` = 'Pending' and `pending` = true.
+	 * @return array Synthetic transaction array so callers treat the refund as submitted.
 	 */
-	public function init_pending( \WC_Order $order, $transaction_data, $mode, $refund_order = null ) {
+	public function init_pending( \WC_Order $order, $transaction_data ) {
 		$payee_reference = $transaction_data->getPayeeReference();
 		$amount          = $transaction_data->getAmount();
+		$created         = gmdate( 'c' );
 
-		$refund_id = 0;
-		if ( $refund_order instanceof \WC_Order_Refund ) {
-			$refund_id = $refund_order->get_id();
-		} else {
-			// WooCommerce creates the refund before the gateway's process_refund() runs.
-			$refunds = $order->get_refunds();
-			$refund  = reset( $refunds );
-			if ( $refund instanceof \WC_Order_Refund ) {
-				$refund_id = $refund->get_id();
-			}
-		}
-
-		$context = array(
-			'action'           => 'init_pending_reversal',
-			'order_id'         => $order->get_id(),
-			'order_number'     => $order->get_order_number(),
-			'payment_order_id' => $order->get_meta( '_payex_paymentorder_id' ),
-			'payee_reference'  => $payee_reference,
-			'amount'           => $amount,
-			'refund_id'        => $refund_id,
-			'mode'             => $mode,
-		);
-
-		// Reload order meta to ensure we have the latest changes and avoid conflicts from parallel scripts.
+		// Reload to avoid clobbering meta written while the reversal request was in flight.
 		$order->read_meta_data();
-		$pending = $this->get_pending( $order );
-
+		$pending                     = $this->get_pending( $order );
 		$pending[ $payee_reference ] = array(
-			'amount'    => $amount,
-			'created'   => gmdate( 'c' ),
-			'refund_id' => $refund_id,
-			'mode'      => $mode,
-			'lines'     => null,
+			'amount'  => $amount,
+			'created' => $created,
 		);
-
-		$order->update_meta_data( self::PENDING_REVERSALS_META, $pending );
-		$order->save_meta_data();
+		$this->save_pending( $order, $pending );
 
 		$order->add_order_note(
 			sprintf(
@@ -246,15 +185,27 @@ class AsyncReversal {
 		// Safety net if the callback never arrives; non-fatal, schedule_recheck() logs a failure.
 		$this->schedule_recheck( $order, 0 );
 
-		Swedbank_Pay()->logger()->info( "[ASYNC REVERSAL]: Reversal accepted asynchronously (HTTP 202) for order #{$order->get_order_number()}. Awaiting confirmation via callback.", $context );
+		Swedbank_Pay()->logger()->info(
+			"[ASYNC REVERSAL]: Reversal accepted asynchronously (HTTP 202) for order #{$order->get_order_number()}. Awaiting confirmation via callback.",
+			array(
+				'action'           => 'init_pending_reversal',
+				'order_id'         => $order->get_id(),
+				'order_number'     => $order->get_order_number(),
+				'payment_order_id' => $order->get_meta( '_payex_paymentorder_id' ),
+				'payee_reference'  => $payee_reference,
+				'amount'           => $amount,
+			)
+		);
 
+		// `number` is empty because no transaction exists yet; the 202 branches return this
+		// straight to the caller so it never reaches process_transaction().
 		return array(
 			'number'         => '',
 			'type'           => OrderManagement::TYPE_REVERSAL,
 			'state'          => 'Pending',
 			'amount'         => $amount,
-			'created'        => gmdate( 'c' ),
-			'updated'        => gmdate( 'c' ),
+			'created'        => $created,
+			'updated'        => $created,
 			'description'    => sprintf( 'Refund Order #%s', $order->get_order_number() ),
 			'payeeReference' => $payee_reference,
 			'pending'        => true,
@@ -273,40 +224,16 @@ class AsyncReversal {
 	}
 
 	/**
-	 * Update a single field on a pending reversal entry.
-	 *
-	 * @param \WC_Order $order The order.
-	 * @param string    $payee_reference The pending entry key.
-	 * @param string    $field The field to set.
-	 * @param mixed     $value The value to set.
-	 *
-	 * @return void
-	 */
-	public function set_pending_field( \WC_Order $order, $payee_reference, $field, $value ) {
-		$order->read_meta_data();
-		$pending = $this->get_pending( $order );
-		if ( ! isset( $pending[ $payee_reference ] ) ) {
-			return;
-		}
-
-		$pending[ $payee_reference ][ $field ] = $value;
-		$order->update_meta_data( self::PENDING_REVERSALS_META, $pending );
-		$order->save_meta_data();
-	}
-
-	/**
 	 * Resolve pending reversals against the payment order.
 	 *
-	 * Confirmed reversals are found in `financialTransactions` and processed through the
-	 * regular transaction handling. Failed reversals are found in `postPurchaseFailedAttempts`
-	 * and put the order on hold. Entries that appear in neither are left pending.
+	 * Confirmed reversals are processed through the regular transaction handling; rejected ones
+	 * put the order on hold. Entries appearing in neither list are left pending.
 	 *
 	 * @param \WC_Order $order The order to check.
 	 *
-	 * @return true|\WP_Error True when nothing is left to do (including nothing pending).
+	 * @return true|\WP_Error True when nothing is left to do, including nothing pending.
 	 */
 	public function check_pending_reversals( \WC_Order $order ) {
-		$order->read_meta_data();
 		$pending = $this->get_pending( $order );
 		if ( empty( $pending ) ) {
 			return true;
@@ -317,11 +244,10 @@ class AsyncReversal {
 			return new \WP_Error( 'missing_payment_id', 'Payment order ID is unknown.' );
 		}
 
-		$gateway = swedbank_pay_get_payment_method( $order );
-		if ( ! $gateway || ! property_exists( $gateway, 'api' ) ) {
-			return new \WP_Error( 'missing_gateway', 'Unable to retrieve the payment gateway instance.' );
+		$api = $this->get_api( $order );
+		if ( is_wp_error( $api ) ) {
+			return $api;
 		}
-		$api = $gateway->api;
 
 		$context = array(
 			'action'           => 'check_pending_reversals',
@@ -331,15 +257,14 @@ class AsyncReversal {
 			'pending'          => array_keys( $pending ),
 		);
 
-		// Check confirmed reversals in the financial transactions list.
 		LogUtility::$title = "[ASYNC REVERSAL]: Retrieve financial transactions for order #{$order->get_order_number()}";
 		$result            = $api->request( 'GET', "{$payment_order_id}/financialtransactions" );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
-		$transactions_list = $result['financialTransactions']['financialTransactionsList'] ?? array();
-		foreach ( $transactions_list as $transaction ) {
+		$confirmed = false;
+		foreach ( $result['financialTransactions']['financialTransactionsList'] ?? array() as $transaction ) {
 			if ( OrderManagement::TYPE_REVERSAL !== ( $transaction['type'] ?? '' ) ) {
 				continue;
 			}
@@ -349,6 +274,7 @@ class AsyncReversal {
 				continue;
 			}
 
+			// process_transaction() adds the refund order note and moves the order status.
 			$process_result = $api->process_transaction( $order, $transaction );
 			if ( is_wp_error( $process_result ) ) {
 				Swedbank_Pay()->logger()->error( "[ASYNC REVERSAL]: Failed to process confirmed reversal #{$transaction['number']} for order #{$order->get_order_number()}: {$process_result->get_error_message()}", $context );
@@ -356,70 +282,43 @@ class AsyncReversal {
 			}
 
 			unset( $pending[ $payee_reference ] );
-			$this->save_pending( $order, $pending );
-
-			$order->add_order_note(
-				sprintf(
-					// translators: %s: refund amount.
-					__( 'Swedbank Pay has confirmed the refund of %s. The money is on its way back to the customer.', 'swedbank-pay-payment-menu' ),
-					wc_price( $transaction['amount'] / 100, array( 'currency' => $order->get_currency() ) )
-				)
-			);
+			$confirmed = true;
 
 			Swedbank_Pay()->logger()->info( "[ASYNC REVERSAL]: Reversal confirmed for order #{$order->get_order_number()}. Transaction: #{$transaction['number']}.", $context );
+		}
+
+		if ( $confirmed ) {
+			$this->save_pending( $order, $pending );
 		}
 
 		if ( empty( $pending ) ) {
 			return true;
 		}
 
-		// Check failed reversals in the post purchase failed attempts list.
 		$failed_attempts = $this->get_failed_attempts( $api, $order, $payment_order_id );
 		if ( is_wp_error( $failed_attempts ) ) {
 			return $failed_attempts;
 		}
 
-		$seen = $this->get_seen_failed_attempts( $order );
 		foreach ( $failed_attempts as $attempt ) {
-			// Unclear which field name is used; log rather than skip an attempt carrying neither.
-			if ( ! isset( $attempt['transactionType'] ) && ! isset( $attempt['type'] ) ) {
-				Swedbank_Pay()->logger()->error(
-					"[ASYNC REVERSAL]: Failed attempt for order #{$order->get_order_number()} has no recognised type field: " . wp_json_encode( $attempt ),
-					$context
-				);
-				continue;
-			}
-
-			$type = $attempt['transactionType'] ?? $attempt['type'];
+			$type = $attempt['transactionType'] ?? $attempt['type'] ?? '';
 			if ( OrderManagement::TYPE_REVERSAL !== $type ) {
 				continue;
 			}
 
-			$number = (string) ( $attempt['number'] ?? '' );
-
-			// Already handled on an earlier callback for this order.
-			if ( '' !== $number && in_array( $number, $seen, true ) ) {
-				continue;
-			}
-
 			// A failed attempt carries no payeeReference, so infer which entry it belongs to.
-			$entry_reference = $this->match_pending_to_attempt( $pending, $attempt );
-
-			if ( '' !== $number ) {
-				$seen[] = $number;
-			}
-
-			if ( null === $entry_reference ) {
+			$payee_reference = $this->match_pending_to_attempt( $pending, $attempt );
+			if ( null === $payee_reference ) {
 				continue;
 			}
 
-			$entry = $pending[ $entry_reference ];
-			unset( $pending[ $entry_reference ] );
-			$this->save_pending( $order, $pending );
+			$amount = $pending[ $payee_reference ]['amount'] ?? 0;
+			unset( $pending[ $payee_reference ] );
 
-			$this->handle_failed_reversal( $order, $entry_reference, $entry, $attempt );
+			// Save before setting the status, so the on-hold transition does not persist a stale entry.
+			$this->save_pending( $order, $pending );
+			$this->handle_failed_reversal( $order, $amount, $attempt );
 		}
-		$this->save_seen_failed_attempts( $order, $seen );
 
 		if ( ! empty( $pending ) ) {
 			Swedbank_Pay()->logger()->debug( '[ASYNC REVERSAL]: Reversal(s) still awaiting confirmation: ' . implode( ', ', array_keys( $pending ) ), $context );
@@ -472,183 +371,86 @@ class AsyncReversal {
 	private function match_pending_to_attempt( array $pending, array $attempt ) {
 		$attempt_created = strtotime( $attempt['created'] ?? '' );
 
-		$match         = null;
-		$match_created = null;
 		foreach ( $pending as $payee_reference => $entry ) {
 			$entry_created = strtotime( $entry['created'] ?? '' );
 
-			// Ignore attempts that predate the reversal; they belong to an earlier refund.
+			// Ignore attempts predating the reversal; they belong to an earlier refund.
 			if ( false !== $attempt_created && false !== $entry_created
 				&& $attempt_created < $entry_created - self::FAILED_ATTEMPT_TOLERANCE
 			) {
 				continue;
 			}
 
-			if ( null === $match_created || ( false !== $entry_created && $entry_created < $match_created ) ) {
-				$match         = (string) $payee_reference;
-				$match_created = $entry_created;
-			}
+			return (string) $payee_reference;
 		}
 
-		return $match;
-	}
-
-	/**
-	 * Get the failed attempt numbers that have already been handled for an order.
-	 *
-	 * @param \WC_Order $order The order.
-	 *
-	 * @return array
-	 */
-	private function get_seen_failed_attempts( \WC_Order $order ) {
-		$seen = $order->get_meta( self::SEEN_FAILED_ATTEMPTS_META );
-
-		return empty( $seen ) ? array() : array_map( 'strval', (array) $seen );
-	}
-
-	/**
-	 * Persist the handled failed attempt numbers.
-	 *
-	 * @param \WC_Order $order The order.
-	 * @param array     $seen The failed attempt numbers.
-	 *
-	 * @return void
-	 */
-	private function save_seen_failed_attempts( \WC_Order $order, array $seen ) {
-		$order->update_meta_data( self::SEEN_FAILED_ATTEMPTS_META, array_values( array_unique( $seen ) ) );
-		$order->save_meta_data();
+		return null;
 	}
 
 	/**
 	 * Handle a reversal that Swedbank Pay reported as failed.
 	 *
-	 * Puts the order on hold to alert the merchant and removes the WooCommerce refund
-	 * so that the order totals are correct and the refund can be retried.
-	 *
 	 * @param \WC_Order $order The order.
-	 * @param string    $payee_reference The payee reference of the failed reversal.
-	 * @param array     $entry The pending reversal entry.
+	 * @param int       $amount The reversal amount, in minor units.
 	 * @param array     $attempt The failed attempt data from Swedbank Pay.
 	 *
 	 * @return void
 	 */
-	private function handle_failed_reversal( \WC_Order $order, $payee_reference, array $entry, array $attempt ) {
-		$context = array(
-			'action'           => 'handle_failed_reversal',
-			'order_id'         => $order->get_id(),
-			'order_number'     => $order->get_order_number(),
-			'payment_order_id' => $order->get_meta( '_payex_paymentorder_id' ),
-			'payee_reference'  => $payee_reference,
-			'entry'            => $entry,
-			'failed_attempt'   => $attempt,
+	private function handle_failed_reversal( \WC_Order $order, $amount, array $attempt ) {
+		Swedbank_Pay()->logger()->error(
+			"[ASYNC REVERSAL]: Reversal failed for order #{$order->get_order_number()}. Failed attempt: " . wp_json_encode( $attempt ),
+			array(
+				'action'           => 'handle_failed_reversal',
+				'order_id'         => $order->get_id(),
+				'order_number'     => $order->get_order_number(),
+				'payment_order_id' => $order->get_meta( '_payex_paymentorder_id' ),
+				'amount'           => $amount,
+				'failed_attempt'   => $attempt,
+			)
 		);
 
-		Swedbank_Pay()->logger()->error( "[ASYNC REVERSAL]: Reversal failed for order #{$order->get_order_number()}. Failed attempt: " . wp_json_encode( $attempt ), $context );
-
-		$message = sprintf(
-			// translators: %s: refund amount.
-			__( 'The refund of %s could not be completed by Swedbank Pay. No money has been returned to the customer. The order has been set to on hold so you can review it and try the refund again.', 'swedbank-pay-payment-menu' ),
-			wc_price( $entry['amount'] / 100, array( 'currency' => $order->get_currency() ) )
+		$this->set_on_hold(
+			$order,
+			sprintf(
+				// translators: %s: refund amount.
+				__( 'The refund of %s could not be completed by Swedbank Pay. No money has been returned to the customer. The order has been set to on hold so you can review it and try the refund again.', 'swedbank-pay-payment-menu' ),
+				wc_price( $amount / 100, array( 'currency' => $order->get_currency() ) )
+			)
 		);
-
-		$gateway = swedbank_pay_get_payment_method( $order );
-		if ( $gateway && property_exists( $gateway, 'api' ) ) {
-			$gateway->api->update_order_status( $order, 'on-hold', $order->get_transaction_id(), $message );
-		} else {
-			$order->update_status( 'on-hold', $message );
-		}
-
-		/**
-		 * Whether to remove the WooCommerce refund when Swedbank Pay rejected the reversal.
-		 *
-		 * Defaults to keeping it, which is how the other Krokedil gateways behave: the refund
-		 * stands, the order goes on hold, and the merchant decides what to do. Returning true
-		 * removes the refund so the order totals match the money actually moved, at the cost
-		 * of leaving any stock adjustments behind.
-		 *
-		 * @param bool      $delete Whether to delete the refund. Default false.
-		 * @param \WC_Order $order The order the reversal failed for.
-		 * @param array     $entry The pending reversal entry.
-		 */
-		$delete_refund = apply_filters( 'swedbank_pay_delete_failed_refund', false, $order, $entry );
-
-		if ( ! $delete_refund ) {
-			return;
-		}
-
-		if ( ! empty( $entry['refund_id'] ) ) {
-			$refund = wc_get_order( $entry['refund_id'] );
-			if ( $refund instanceof \WC_Order_Refund && $refund->get_parent_id() === $order->get_id() ) {
-				$refund->delete( true );
-				$order->add_order_note(
-					__( 'The refund entry was removed from the order so the order totals are correct. If any items were returned to stock, please adjust the stock manually.', 'swedbank-pay-payment-menu' )
-				);
-			}
-		}
-
-		// Only roll back the plugin's own refunded-items tracking when the refund itself was
-		// removed; otherwise the lines would be refundable again while the refund still stands.
-		if ( 'items' === ( $entry['mode'] ?? '' ) && ! empty( $entry['lines'] ) ) {
-			$this->rollback_refunded_items( $order, (array) $entry['lines'] );
-		}
 	}
 
 	/**
-	 * Subtract the given refund lines from the `_payex_refunded_items` meta.
-	 *
-	 * Inverse of Swedbank_Pay_Payment_Actions::save_refunded_items(); without this a failed
-	 * items refund would permanently block the lines from being refunded again.
+	 * Get the API instance for an order.
 	 *
 	 * @param \WC_Order $order The order.
-	 * @param array     $lines The refund lines (keyed by order item ID, each with a 'qty').
+	 *
+	 * @return \SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Api|\WP_Error
+	 */
+	private function get_api( \WC_Order $order ) {
+		$gateway = swedbank_pay_get_payment_method( $order );
+		if ( ! $gateway || ! property_exists( $gateway, 'api' ) ) {
+			return new \WP_Error( 'missing_gateway', 'Unable to retrieve the payment gateway instance.' );
+		}
+
+		return $gateway->api;
+	}
+
+	/**
+	 * Put the order on hold with a note.
+	 *
+	 * @param \WC_Order $order The order.
+	 * @param string    $message The note to add.
 	 *
 	 * @return void
 	 */
-	private function rollback_refunded_items( \WC_Order $order, array $lines ) {
-		$current_items = $order->get_meta( '_payex_refunded_items' );
-		$current_items = empty( $current_items ) ? array() : (array) $current_items;
-		if ( empty( $current_items ) ) {
+	private function set_on_hold( \WC_Order $order, $message ) {
+		$api = $this->get_api( $order );
+		if ( is_wp_error( $api ) ) {
+			$order->update_status( 'on-hold', $message );
 			return;
 		}
 
-		foreach ( $lines as $item_id => $line ) {
-			$qty = max( 1, (int) ( $line['qty'] ?? 1 ) );
-
-			$item = $order->get_item( $item_id );
-			if ( ! $item ) {
-				continue;
-			}
-
-			switch ( $item->get_type() ) {
-				case 'line_item':
-					// The item is a WC_Order_Item_Product here, so get_product() is available.
-					$product   = $item->get_product();
-					$reference = $product ? $product->get_sku() : 'other';
-					break;
-				case 'shipping':
-				case 'fee':
-				case 'coupon':
-					$reference = $item->get_type();
-					break;
-				default:
-					$reference = 'other';
-					break;
-			}
-
-			foreach ( $current_items as $key => &$current_item ) {
-				if ( ( $current_item[ Swedbank_Pay_Order_Item::FIELD_REFERENCE ] ?? '' ) === $reference ) {
-					$current_item[ Swedbank_Pay_Order_Item::FIELD_QTY ] -= $qty;
-					if ( $current_item[ Swedbank_Pay_Order_Item::FIELD_QTY ] <= 0 ) {
-						unset( $current_items[ $key ] );
-					}
-					break;
-				}
-			}
-			unset( $current_item );
-		}
-
-		$order->update_meta_data( '_payex_refunded_items', array_values( $current_items ) );
-		$order->save_meta_data();
+		$api->update_order_status( $order, 'on-hold', $order->get_transaction_id(), $message );
 	}
 
 	/**

--- a/src/AsyncReversal.php
+++ b/src/AsyncReversal.php
@@ -238,7 +238,7 @@ class AsyncReversal {
 		$order->add_order_note(
 			sprintf(
 				// translators: %s: refund amount.
-				__( 'The refund of %s has been sent to Swedbank Pay and is awaiting confirmation. This usually takes less than a minute, but can in rare cases take up to 3 days.', 'swedbank-pay-payment-menu' ),
+				__( 'The refund of %s has been sent to Swedbank Pay and is awaiting confirmation.', 'swedbank-pay-payment-menu' ),
 				wc_price( $amount / 100, array( 'currency' => $order->get_currency() ) )
 			)
 		);

--- a/src/AsyncReversal.php
+++ b/src/AsyncReversal.php
@@ -91,7 +91,7 @@ class AsyncReversal {
 			return false;
 		}
 
-		as_schedule_single_action(
+		$action_id = as_schedule_single_action(
 			time() + $delays[ $attempt ],
 			self::RECHECK_HOOK,
 			array(
@@ -99,6 +99,22 @@ class AsyncReversal {
 				'attempt'  => $attempt,
 			)
 		);
+
+		// Action Scheduler returns 0 when it could not store the action. Reporting that as a
+		// success would retire the safety net without telling anyone, leaving the reversal
+		// pending forever, so treat it as a failure and let the caller escalate instead.
+		if ( 0 === $action_id ) {
+			Swedbank_Pay()->logger()->error(
+				"[ASYNC REVERSAL]: Failed to schedule recheck attempt {$attempt} for order #{$order->get_order_number()}.",
+				array(
+					'action'   => 'schedule_recheck',
+					'order_id' => $order->get_id(),
+					'attempt'  => $attempt,
+				)
+			);
+
+			return false;
+		}
 
 		return true;
 	}
@@ -240,7 +256,10 @@ class AsyncReversal {
 			)
 		);
 
-		// Safety net in case the payee callback never arrives.
+		// Safety net in case the payee callback never arrives. A failure here is logged by
+		// schedule_recheck() and left non-fatal on purpose: the reversal has been accepted, the
+		// callback is still the primary route, and maybe_block_pending_reversal() re-checks on
+		// the merchant's next payment action regardless.
 		$this->schedule_recheck( $order, 0 );
 
 		Swedbank_Pay()->logger()->info( "[ASYNC REVERSAL]: Reversal accepted asynchronously (HTTP 202) for order #{$order->get_order_number()}. Awaiting confirmation via callback.", $context );

--- a/src/AsyncReversal.php
+++ b/src/AsyncReversal.php
@@ -263,6 +263,16 @@ class AsyncReversal {
 			return $result;
 		}
 
+		// Confirming a reversal moves the order to refunded, and that status change would other-
+		// wise re-enter the refund handler and attempt a second reversal. Same guard the admin
+		// payment actions use. Only put back what was there: the handler is not registered in
+		// every context, and adding it here would switch on order management that was never on.
+		$status_hook     = 'Swedbank_Pay_Admin::order_status_changed_transaction';
+		$status_priority = has_action( 'woocommerce_order_status_changed', $status_hook );
+		if ( false !== $status_priority ) {
+			remove_action( 'woocommerce_order_status_changed', $status_hook, $status_priority );
+		}
+
 		$confirmed = false;
 		foreach ( $result['financialTransactions']['financialTransactionsList'] ?? array() as $transaction ) {
 			if ( OrderManagement::TYPE_REVERSAL !== ( $transaction['type'] ?? '' ) ) {
@@ -285,6 +295,10 @@ class AsyncReversal {
 			$confirmed = true;
 
 			Swedbank_Pay()->logger()->info( "[ASYNC REVERSAL]: Reversal confirmed for order #{$order->get_order_number()}. Transaction: #{$transaction['number']}.", $context );
+		}
+
+		if ( false !== $status_priority ) {
+			add_action( 'woocommerce_order_status_changed', $status_hook, $status_priority, 3 );
 		}
 
 		if ( $confirmed ) {

--- a/src/AsyncReversal.php
+++ b/src/AsyncReversal.php
@@ -294,31 +294,36 @@ class AsyncReversal {
 		}
 
 		$confirmed = false;
-		foreach ( $result['financialTransactions']['financialTransactionsList'] ?? array() as $transaction ) {
-			if ( OrderManagement::TYPE_REVERSAL !== ( $transaction['type'] ?? '' ) ) {
-				continue;
+
+		// finally: leaving the handler unhooked because saving the order threw would silently
+		// disable order management for the rest of the request.
+		try {
+			foreach ( $result['financialTransactions']['financialTransactionsList'] ?? array() as $transaction ) {
+				if ( OrderManagement::TYPE_REVERSAL !== ( $transaction['type'] ?? '' ) ) {
+					continue;
+				}
+
+				$payee_reference = $transaction['payeeReference'] ?? '';
+				if ( ! isset( $pending[ $payee_reference ] ) ) {
+					continue;
+				}
+
+				// process_transaction() adds the refund order note and moves the order status.
+				$process_result = $api->process_transaction( $order, $transaction );
+				if ( is_wp_error( $process_result ) ) {
+					Swedbank_Pay()->logger()->error( "[ASYNC REVERSAL]: Failed to process confirmed reversal #{$transaction['number']} for order #{$order->get_order_number()}: {$process_result->get_error_message()}", $context );
+					continue;
+				}
+
+				unset( $pending[ $payee_reference ] );
+				$confirmed = true;
+
+				Swedbank_Pay()->logger()->info( "[ASYNC REVERSAL]: Reversal confirmed for order #{$order->get_order_number()}. Transaction: #{$transaction['number']}.", $context );
 			}
-
-			$payee_reference = $transaction['payeeReference'] ?? '';
-			if ( ! isset( $pending[ $payee_reference ] ) ) {
-				continue;
+		} finally {
+			if ( false !== $status_priority ) {
+				add_action( 'woocommerce_order_status_changed', $status_hook, $status_priority, 3 );
 			}
-
-			// process_transaction() adds the refund order note and moves the order status.
-			$process_result = $api->process_transaction( $order, $transaction );
-			if ( is_wp_error( $process_result ) ) {
-				Swedbank_Pay()->logger()->error( "[ASYNC REVERSAL]: Failed to process confirmed reversal #{$transaction['number']} for order #{$order->get_order_number()}: {$process_result->get_error_message()}", $context );
-				continue;
-			}
-
-			unset( $pending[ $payee_reference ] );
-			$confirmed = true;
-
-			Swedbank_Pay()->logger()->info( "[ASYNC REVERSAL]: Reversal confirmed for order #{$order->get_order_number()}. Transaction: #{$transaction['number']}.", $context );
-		}
-
-		if ( false !== $status_priority ) {
-			add_action( 'woocommerce_order_status_changed', $status_hook, $status_priority, 3 );
 		}
 
 		if ( $confirmed ) {

--- a/swedbank-pay-payment-menu.php
+++ b/swedbank-pay-payment-menu.php
@@ -19,6 +19,7 @@
  */
 
 use Krokedil\Swedbank\Pay\Assets;
+use Krokedil\Swedbank\Pay\AsyncReversal;
 use Krokedil\Swedbank\Pay\Gateways\SplitInstrumentGateway;
 use SwedbankPay\Checkout\WooCommerce\Swedbank_Pay_Plugin;
 use Krokedil\Swedbank\Pay\OrderManagement;
@@ -55,6 +56,13 @@ class Swedbank_Pay_Payment_Menu extends Swedbank_Pay_Plugin {
 	 * @var OrderManagement
 	 */
 	private $order_management;
+
+	/**
+	 * Async Reversal handler.
+	 *
+	 * @var AsyncReversal
+	 */
+	private $async_reversal;
 
 	/**
 	 * Logger instance.
@@ -125,6 +133,15 @@ class Swedbank_Pay_Payment_Menu extends Swedbank_Pay_Plugin {
 	 */
 	public function order_management() {
 		return $this->order_management;
+	}
+
+	/**
+	 * Handle for the async reversal instance.
+	 *
+	 * @return AsyncReversal
+	 */
+	public function async_reversal() {
+		return $this->async_reversal;
 	}
 
 	/**
@@ -219,6 +236,7 @@ class Swedbank_Pay_Payment_Menu extends Swedbank_Pay_Plugin {
 		);
 		$this->system_report    = new SystemReport( 'payex_checkout', 'Swedbank Pay', $system_report_options );
 		$this->order_management = OrderManagement::get_instance();
+		$this->async_reversal   = AsyncReversal::get_instance();
 		$this->assets           = new Assets();
 		// Register the split instruments for the gateway as soon as possible.
 		add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateways' ) );


### PR DESCRIPTION
Payment methods that process refunds asynchronously, such as Banklink in the Baltics, answer the reversal request with HTTP 202 Accepted and report the outcome in a later callback. The refund is now registered in WooCommerce immediately and marked as awaiting confirmation.

When the callback arrives, a confirmed reversal is processed as usual, while a rejected reversal puts the order on hold so the merchant can review it. No other payment action can be performed on the order while a reversal is awaiting confirmation. Should the callback never arrive, the refund is rechecked on a schedule for up to three days, after which the order is put on hold for manual verification.

https://app.clickup.com/t/2423261/869bxy61v